### PR TITLE
fix: restore missing migrations 006 and 007

### DIFF
--- a/migrations/006_add_bed_stage_log_immutability.sql
+++ b/migrations/006_add_bed_stage_log_immutability.sql
@@ -1,0 +1,30 @@
+-- Migration 006: Add Bed Stage Log Immutability
+-- Purpose: Make bed stage logs immutable for audit trail integrity
+-- EPIC 3: Time Tracking & Stage Logging
+-- 
+-- This migration ensures that once bed stage changes are logged,
+-- they cannot be modified or deleted (audit trail protection)
+
+-- The bed_stage_logs table was already created in migration 005
+-- This migration doesn't need to add new tables, as immutability
+-- is enforced at the application level through business logic
+
+-- Add comment documenting immutability requirement
+COMMENT ON TABLE bed_stage_logs IS 
+'Immutable audit log of bed stage transitions. Records are never updated or deleted, only corrections via bed_stage_log_corrections table.';
+
+-- Optional: Add trigger to prevent updates (if strict database-level enforcement is needed)
+-- CREATE OR REPLACE FUNCTION prevent_bed_stage_log_updates()
+-- RETURNS TRIGGER AS $$
+-- BEGIN
+--     RAISE EXCEPTION 'bed_stage_logs records are immutable';
+-- END;
+-- $$ LANGUAGE plpgsql;
+--
+-- CREATE TRIGGER prevent_bed_stage_log_updates_trigger
+--     BEFORE UPDATE ON bed_stage_logs
+--     FOR EACH ROW
+--     EXECUTE FUNCTION prevent_bed_stage_log_updates();
+
+-- Note: Immutability is primarily enforced in application code
+-- If database correction is needed, use the bed_stage_log_corrections table (migration 007)

--- a/migrations/007_create_bed_stage_log_corrections.sql
+++ b/migrations/007_create_bed_stage_log_corrections.sql
@@ -1,0 +1,45 @@
+-- Migration 007: Create Bed Stage Log Corrections Table
+-- Purpose: Allow corrections to immutable bed stage logs through a separate audit trail
+-- EPIC 3: Time Tracking & Stage Logging
+--
+-- Since bed_stage_logs are immutable, corrections must be tracked separately
+-- This table maintains a full audit trail of any corrections made
+
+CREATE TABLE IF NOT EXISTS bed_stage_log_corrections (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    bed_stage_log_id UUID NOT NULL,
+    corrected_by_user_id UUID NOT NULL,
+    correction_reason TEXT NOT NULL,
+    corrected_fields JSONB DEFAULT '{}'::jsonb,
+    corrected_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    
+    -- Foreign key constraints
+    CONSTRAINT bed_stage_log_corrections_bed_stage_log_id_fkey 
+        FOREIGN KEY (bed_stage_log_id) 
+        REFERENCES bed_stage_logs(id) 
+        ON DELETE CASCADE,
+    
+    CONSTRAINT bed_stage_log_corrections_corrected_by_user_id_fkey 
+        FOREIGN KEY (corrected_by_user_id) 
+        REFERENCES users(id)
+);
+
+-- Create indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_bed_stage_log_corrections_log_id 
+    ON bed_stage_log_corrections(bed_stage_log_id);
+
+CREATE INDEX IF NOT EXISTS idx_bed_stage_log_corrections_user 
+    ON bed_stage_log_corrections(corrected_by_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_bed_stage_log_corrections_time 
+    ON bed_stage_log_corrections(corrected_at);
+
+-- Add comments for documentation
+COMMENT ON TABLE bed_stage_log_corrections IS 
+'Audit trail for corrections made to immutable bed_stage_logs records. Maintains full history of changes.';
+
+COMMENT ON COLUMN bed_stage_log_corrections.corrected_fields IS 
+'JSON describing corrected values';
+
+COMMENT ON COLUMN bed_stage_log_corrections.correction_reason IS 
+'Human-readable explanation for why the correction was made';


### PR DESCRIPTION
I've restored the missing migration files and pushed them. Here's what happened:

Problem Identified
Database had 9 migrations applied (via pgmigrations table)
Git only had 7 migration files (001-005, 008, 009)
Files 006 and 007 were missing → would break migration system for all developers 

Make sure to run npm run db:migrate