### PR TITLE
feat: add confirmation prompt for critical stage changes (#20)

### DIFF
--- a/check-env.js
+++ b/check-env.js
@@ -1,0 +1,39 @@
+
+const fs = require('fs');
+const path = require('path');
+const { z } = require('zod');
+const dotenv = require('dotenv');
+
+// Load .env.local manually
+const envPath = path.resolve(process.cwd(), '.env.local');
+if (fs.existsSync(envPath)) {
+    const envConfig = dotenv.parse(fs.readFileSync(envPath));
+    for (const k in envConfig) {
+        process.env[k] = envConfig[k];
+    }
+}
+
+const envSchema = z.object({
+    DATABASE_URL: z.string().optional(),
+    DATABASE_URL_ENCRYPTED: z.string().optional(),
+    SESSION_SECRET: z.string().min(32, 'SESSION_SECRET must be at least 32 characters'),
+    ENCRYPTION_KEY: z.string().optional(),
+    NEXT_PUBLIC_APP_URL: z.string()
+        .url('NEXT_PUBLIC_APP_URL must be a valid URL')
+        .default('http://localhost:3000'),
+    NODE_ENV: z.enum(['development', 'staging', 'production']).default('development'),
+    RED_ALERT_THRESHOLD_MS: z.coerce.number().int().positive().default(10800000),
+    OPENAI_API_KEY: z.string().optional(),
+    OPENAI_API_KEY_ENCRYPTED: z.string().optional(),
+});
+
+console.log('Validating environment variables...');
+const result = envSchema.safeParse(process.env);
+
+if (!result.success) {
+    console.error('Validation FAILED:', JSON.stringify(result.error.flatten(), null, 2));
+    process.exit(1);
+} else {
+    console.log('Validation PASSED');
+    console.log('SESSION_SECRET length:', result.data.SESSION_SECRET.length);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1662,7 +1662,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1673,7 +1672,6 @@
       "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -1686,7 +1684,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1697,7 +1694,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1747,7 +1743,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -2234,7 +2229,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2693,7 +2687,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3420,7 +3413,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3594,7 +3586,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4927,7 +4918,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5662,7 +5652,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -5812,7 +5801,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6004,7 +5992,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6014,7 +6001,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6755,7 +6741,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6919,7 +6904,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6964,7 +6948,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7146,7 +7129,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/admin/stages/page.tsx
+++ b/src/app/admin/stages/page.tsx
@@ -1,6 +1,8 @@
 import { getStages } from '@/features/stage-management/actions/stage-actions';
 import { StageList } from '@/features/stage-management/components/StageList';
 
+export const dynamic = 'force-dynamic';
+
 export default async function StagesPage() {
   const stages = await getStages();
   return (

--- a/src/features/bed-dashboard/components/BedDashboardClient.tsx
+++ b/src/features/bed-dashboard/components/BedDashboardClient.tsx
@@ -8,6 +8,8 @@ import { useCallback } from 'react'
 import { BedGrid } from './BedGrid'
 import type { BedGridData, BedWithElapsedTime } from '../types/bed'
 import { SupervisorOverrideModal } from './SupervisorOverrideModal'
+import { ConfirmationModal } from './ConfirmationModal'
+import { DashboardSettings } from './DashboardSettings'
 import { useBedStageUpdate } from '../hooks/useBedStageUpdate'
 
 interface BedDashboardClientProps {
@@ -27,11 +29,17 @@ export function BedDashboardClient({ initialData }: BedDashboardClientProps) {
     handleRefresh,
     handleStageSelect,
     handleOverrideApprove,
+
     closeOverrideModal,
+    confirmationState,
+    handleConfirmationConfirm,
+    closeConfirmationModal,
+    settings,
+    toggleConfirmation,
   } = useBedStageUpdate(initialData)
 
   // TODO: Implement real-time updates (US-1.2)
-  const isLoading = false, connectionStatus = 'connected', reconnect = () => {}
+  const isLoading = false, connectionStatus = 'connected', reconnect = () => { }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const ConnectionStatus = (_props: { status: string; onReconnect: () => void }) => null
 
@@ -43,7 +51,11 @@ export function BedDashboardClient({ initialData }: BedDashboardClientProps) {
   return (
     <div className="space-y-4">
       {/* Connection Status Indicator */}
-      <div className="flex justify-end">
+      <div className="flex justify-end items-center gap-2">
+        <DashboardSettings
+          enabled={settings.confirmCriticalStages}
+          onToggle={toggleConfirmation}
+        />
         <ConnectionStatus status={connectionStatus} onReconnect={reconnect} />
       </div>
 
@@ -70,6 +82,16 @@ export function BedDashboardClient({ initialData }: BedDashboardClientProps) {
         onApprove={handleOverrideApprove}
         onCancel={closeOverrideModal}
         isLoading={isOverrideSubmitting}
+      />
+
+      <ConfirmationModal
+        isOpen={Boolean(confirmationState)}
+        bedNumber={confirmationState?.bedNumber ?? null}
+        fromStageName={confirmationState?.fromStageName ?? null}
+        toStage={confirmationState?.toStage ?? null}
+        onConfirm={handleConfirmationConfirm}
+        onCancel={closeConfirmationModal}
+        isUpdating={confirmationState ? updatingBedId === confirmationState.bedId : false}
       />
     </div>
   )

--- a/src/features/bed-dashboard/components/ConfirmationModal.tsx
+++ b/src/features/bed-dashboard/components/ConfirmationModal.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { memo, useEffect } from 'react'
+import { Button } from '@/shared/components/ui/button'
+import { Loader2, AlertTriangle, X } from 'lucide-react'
+import type { Stage } from '../types/bed'
+import { cn } from '@/shared/lib/utils'
+
+interface ConfirmationModalProps {
+    isOpen: boolean
+    bedNumber: string | null
+    fromStageName: string | null
+    toStage: Stage | null
+    onConfirm: () => void
+    onCancel: () => void
+    isUpdating?: boolean
+}
+
+export const ConfirmationModal = memo(function ConfirmationModal({
+    isOpen,
+    bedNumber,
+    fromStageName,
+    toStage,
+    onConfirm,
+    onCancel,
+    isUpdating = false,
+}: ConfirmationModalProps) {
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (!isOpen) return
+
+            if (e.key === 'Escape') {
+                e.preventDefault()
+                onCancel()
+            } else if (e.key === 'Enter') {
+                e.preventDefault()
+                onConfirm()
+            }
+        }
+
+        if (isOpen) {
+            window.addEventListener('keydown', handleKeyDown)
+        }
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [isOpen, onCancel, onConfirm])
+
+    if (!isOpen) return null
+
+    return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-in fade-in duration-200">
+            <div className="bg-white dark:bg-zinc-900 rounded-lg shadow-lg max-w-md w-full mx-4 p-6 space-y-4 animate-in zoom-in-95 duration-200">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 text-amber-600 dark:text-amber-500">
+                        <AlertTriangle className="h-5 w-5" />
+                        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Confirm Critical Update</h2>
+                    </div>
+                    <button
+                        onClick={onCancel}
+                        className="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+                        disabled={isUpdating}
+                    >
+                        <X className="h-5 w-5" />
+                    </button>
+                </div>
+
+                <div className="space-y-4">
+                    <p className="text-gray-600 dark:text-gray-300">
+                        Are you sure you want to update Bed <span className="font-semibold text-gray-900 dark:text-gray-100">{bedNumber}</span>?
+                    </p>
+
+                    <div className="bg-gray-50 dark:bg-zinc-800/50 rounded-md p-3 space-y-2 text-sm border border-gray-200 dark:border-zinc-700">
+                        <div className="flex justify-between items-center">
+                            <span className="text-gray-500 dark:text-gray-400">From Stage:</span>
+                            <span className="font-medium text-gray-900 dark:text-gray-100">{fromStageName}</span>
+                        </div>
+                        <div className="flex justify-between items-center border-t border-gray-200 dark:border-zinc-700 pt-2">
+                            <span className="text-gray-500 dark:text-gray-400">To Stage:</span>
+                            <span
+                                className={cn("font-bold px-2 py-0.5 rounded text-xs uppercase tracking-wider")}
+                                style={{
+                                    backgroundColor: `${toStage?.colorCode}20`,
+                                    color: toStage?.colorCode,
+                                    borderColor: `${toStage?.colorCode}40`
+                                }}
+                            >
+                                {toStage?.name}
+                            </span>
+                        </div>
+                    </div>
+
+                    <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200 text-xs p-3 rounded-md">
+                        This is a critical stage change. Please verify the patient status before proceeding.
+                    </div>
+                </div>
+
+                <div className="flex justify-end gap-3 pt-2">
+                    <Button
+                        variant="outline"
+                        onClick={onCancel}
+                        disabled={isUpdating}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        onClick={onConfirm}
+                        disabled={isUpdating}
+                    >
+                        {isUpdating ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Updating...
+                            </>
+                        ) : (
+                            'Confirm Update'
+                        )}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    )
+})

--- a/src/features/bed-dashboard/components/DashboardSettings.tsx
+++ b/src/features/bed-dashboard/components/DashboardSettings.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { memo } from 'react'
+import { Button } from '@/shared/components/ui/button'
+import { ShieldCheck, ShieldAlert } from 'lucide-react'
+
+interface DashboardSettingsProps {
+    enabled: boolean
+    onToggle: () => void
+}
+
+export const DashboardSettings = memo(function DashboardSettings({
+    enabled,
+    onToggle,
+}: DashboardSettingsProps) {
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            onClick={onToggle}
+            className={`${enabled
+                    ? 'text-green-600 dark:text-green-400 border-green-200 dark:border-green-800'
+                    : 'text-amber-600 dark:text-amber-400 border-amber-200 dark:border-amber-800'
+                }`}
+            title={enabled ? 'Critical updates require confirmation' : 'Critical updates are instant (Caution!)'}
+        >
+            {enabled ? (
+                <>
+                    <ShieldCheck className="mr-2 h-4 w-4" />
+                    Safety On
+                </>
+            ) : (
+                <>
+                    <ShieldAlert className="mr-2 h-4 w-4" />
+                    Safety Off
+                </>
+            )}
+        </Button>
+    )
+})

--- a/src/features/bed-dashboard/hooks/useBedStageUpdate.ts
+++ b/src/features/bed-dashboard/hooks/useBedStageUpdate.ts
@@ -5,20 +5,15 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import type { BedGridData, BedWithElapsedTime, Stage } from '../types/bed'
+import type { BedGridData, BedWithElapsedTime, Stage, OverrideState, ConfirmationState } from '../types/bed'
 import { useErrorTimers, useSuccessFeedback } from './useBedUpdateState'
 import { useStageUpdateActions } from './useStageUpdateActions'
 
+import { useDashboardSettings } from './useDashboardSettings'
+
 const SUCCESS_FEEDBACK_MS = 3000
 
-export interface OverrideState {
-  bedId: string
-  stageId: string
-  bedNumber: string
-  fromStageName: string | null
-  toStage: Stage
-  reason: string | null
-}
+
 
 interface UseBedStageUpdateReturn {
   data: BedGridData
@@ -33,6 +28,11 @@ interface UseBedStageUpdateReturn {
   handleStageSelect: (bedId: string, stageId: string) => Promise<void>
   handleOverrideApprove: (reason: string) => Promise<void>
   closeOverrideModal: () => void
+  confirmationState: ConfirmationState | null
+  handleConfirmationConfirm: () => Promise<void>
+  closeConfirmationModal: () => void
+  settings: { confirmCriticalStages: boolean }
+  toggleConfirmation: () => void
 }
 
 export function useBedStageUpdate(initialData: BedGridData): UseBedStageUpdateReturn {
@@ -41,10 +41,12 @@ export function useBedStageUpdate(initialData: BedGridData): UseBedStageUpdateRe
   const [updatingBedId, setUpdatingBedId] = useState<string | null>(null)
   const [updatingStageId, setUpdatingStageId] = useState<string | null>(null)
   const [overrideState, setOverrideState] = useState<OverrideState | null>(null)
+  const [confirmationState, setConfirmationState] = useState<ConfirmationState | null>(null)
 
   const { errorByBedId, setTemporaryError, clearError } = useErrorTimers()
   const { lastUpdatedBedId, lastUpdatedStageId, showSuccessFeedback } =
     useSuccessFeedback(SUCCESS_FEEDBACK_MS)
+  const { settings, toggleConfirmation } = useDashboardSettings()
 
   const stageById = useMemo(() => {
     const map = new Map<string, Stage>()
@@ -72,7 +74,24 @@ export function useBedStageUpdate(initialData: BedGridData): UseBedStageUpdateRe
     setOverrideState(null)
   }, [])
 
-  const { isOverrideSubmitting, handleStageSelect, handleOverrideApprove } = useStageUpdateActions({
+  const openConfirmationModal = useCallback(
+    (bed: BedWithElapsedTime, stage: Stage) => {
+      setConfirmationState({
+        bedId: bed.id,
+        stageId: stage.id,
+        bedNumber: bed.bedNumber,
+        fromStageName: bed.currentStage?.name ?? 'Empty',
+        toStage: stage,
+      })
+    },
+    []
+  )
+
+  const closeConfirmationModal = useCallback(() => {
+    setConfirmationState(null)
+  }, [])
+
+  const { isOverrideSubmitting, handleStageSelect, handleOverrideApprove, handleConfirmationConfirm } = useStageUpdateActions({
     data,
     stageById,
     updatingBedId,
@@ -85,6 +104,10 @@ export function useBedStageUpdate(initialData: BedGridData): UseBedStageUpdateRe
     openOverrideModal,
     overrideState,
     closeOverrideModal,
+    openConfirmationModal,
+    confirmationState,
+    closeConfirmationModal,
+    confirmCriticalStages: settings.confirmCriticalStages,
   })
 
   return {
@@ -100,5 +123,10 @@ export function useBedStageUpdate(initialData: BedGridData): UseBedStageUpdateRe
     handleStageSelect,
     handleOverrideApprove,
     closeOverrideModal,
+    confirmationState,
+    handleConfirmationConfirm,
+    closeConfirmationModal,
+    settings,
+    toggleConfirmation,
   }
 }

--- a/src/features/bed-dashboard/hooks/useDashboardSettings.ts
+++ b/src/features/bed-dashboard/hooks/useDashboardSettings.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+const SETTINGS_KEY = 'ewtcs-dashboard-settings'
+
+interface DashboardSettings {
+    confirmCriticalStages: boolean
+}
+
+const DEFAULT_SETTINGS: DashboardSettings = {
+    confirmCriticalStages: true,
+}
+
+export function useDashboardSettings() {
+    const [settings, setSettings] = useState<DashboardSettings>(DEFAULT_SETTINGS)
+    const [isLoaded, setIsLoaded] = useState(false)
+
+    useEffect(() => {
+        try {
+            const stored = localStorage.getItem(SETTINGS_KEY)
+            if (stored) {
+                setSettings({ ...DEFAULT_SETTINGS, ...JSON.parse(stored) })
+            }
+        } catch (e) {
+            console.error('Failed to load dashboard settings', e)
+        } finally {
+            setIsLoaded(true)
+        }
+    }, [])
+
+    const updateSettings = useCallback((newSettings: Partial<DashboardSettings>) => {
+        setSettings(prev => {
+            const next = { ...prev, ...newSettings }
+            localStorage.setItem(SETTINGS_KEY, JSON.stringify(next))
+            return next
+        })
+    }, [])
+
+    const toggleConfirmation = useCallback(() => {
+        updateSettings({ confirmCriticalStages: !settings.confirmCriticalStages })
+    }, [settings.confirmCriticalStages, updateSettings])
+
+    return {
+        settings,
+        isLoaded,
+        updateSettings,
+        toggleConfirmation,
+    }
+}

--- a/src/features/bed-dashboard/hooks/useStageUpdateActions.ts
+++ b/src/features/bed-dashboard/hooks/useStageUpdateActions.ts
@@ -6,9 +6,10 @@
 import { useCallback, useRef, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { useRouter } from 'next/navigation'
-import type { BedGridData, BedWithElapsedTime, Stage } from '../types/bed'
-import type { OverrideState } from './useBedStageUpdate'
+
+import type { BedGridData, BedWithElapsedTime, Stage, OverrideState, ConfirmationState } from '../types/bed'
 import { executeStageUpdate } from '../lib/execute-stage-update'
+import { isCriticalStage } from '../lib/utils'
 
 interface StageUpdateActionsDeps {
   data: BedGridData
@@ -23,12 +24,17 @@ interface StageUpdateActionsDeps {
   openOverrideModal: (bed: BedWithElapsedTime, stage: Stage, reason: string | null) => void
   overrideState: OverrideState | null
   closeOverrideModal: () => void
+  openConfirmationModal: (bed: BedWithElapsedTime, stage: Stage) => void
+  confirmationState: ConfirmationState | null
+  closeConfirmationModal: () => void
+  confirmCriticalStages: boolean
 }
 
 interface StageUpdateActionsResult {
   isOverrideSubmitting: boolean
   handleStageSelect: (bedId: string, stageId: string) => Promise<void>
   handleOverrideApprove: (reason: string) => Promise<void>
+  handleConfirmationConfirm: () => Promise<void>
 }
 
 export function useStageUpdateActions({
@@ -44,6 +50,10 @@ export function useStageUpdateActions({
   openOverrideModal,
   overrideState,
   closeOverrideModal,
+  openConfirmationModal,
+  confirmationState,
+  closeConfirmationModal,
+  confirmCriticalStages,
 }: StageUpdateActionsDeps): StageUpdateActionsResult {
   const router = useRouter()
   const [isOverrideSubmitting, setIsOverrideSubmitting] = useState(false)
@@ -92,10 +102,29 @@ export function useStageUpdateActions({
 
   const handleStageSelect = useCallback(
     async (bedId: string, stageId: string) => {
+      const stage = stageById.get(stageId)
+      const bed = data.beds.find(b => b.id === bedId)
+
+      // Only show confirmation if the setting is enabled AND it's a critical stage
+      if (stage && bed && isCriticalStage(stage.name) && confirmCriticalStages) {
+        openConfirmationModal(bed, stage)
+        return
+      }
+
       await performStageUpdate(bedId, stageId)
     },
-    [performStageUpdate]
+    [performStageUpdate, stageById, data.beds, openConfirmationModal, confirmCriticalStages]
   )
+
+  const handleConfirmationConfirm = useCallback(async () => {
+    if (!confirmationState) return
+
+    // Proceed with the update
+    // Note: performStageUpdate handles validation and override checks internally
+    await performStageUpdate(confirmationState.bedId, confirmationState.stageId)
+
+    closeConfirmationModal()
+  }, [confirmationState, performStageUpdate, closeConfirmationModal])
 
   const handleOverrideApprove = useCallback(
     async (reason: string) => {
@@ -116,5 +145,5 @@ export function useStageUpdateActions({
     [overrideState, performStageUpdate, closeOverrideModal]
   )
 
-  return { isOverrideSubmitting, handleStageSelect, handleOverrideApprove }
+  return { isOverrideSubmitting, handleStageSelect, handleOverrideApprove, handleConfirmationConfirm }
 }

--- a/src/features/bed-dashboard/lib/utils.ts
+++ b/src/features/bed-dashboard/lib/utils.ts
@@ -12,7 +12,7 @@ export function formatElapsedTime(ms: number | null): string {
   }
 
   const totalMinutes = Math.floor(ms / 60000)
-  
+
   if (totalMinutes < 1) {
     return '< 1m'
   }
@@ -106,7 +106,7 @@ export function getDelayColorClasses(isDelayed: boolean): {
       border: 'border-red-700',
     }
   }
-  
+
   return {
     bg: 'bg-zinc-800',
     text: 'text-zinc-300',
@@ -123,7 +123,7 @@ export function calculateOccupancyPercentage(
   beds: Array<{ isOccupied: boolean }>
 ): number {
   if (beds.length === 0) return 0
-  
+
   const occupiedCount = beds.filter(b => b.isOccupied).length
   return Math.round((occupiedCount / beds.length) * 100)
 }
@@ -148,7 +148,7 @@ export function getBedStatistics(
   const available = total - occupied
   const delayed = beds.filter(b => b.isDelayed).length
   const occupancyPercentage = calculateOccupancyPercentage(beds)
-  
+
   // Calculate average elapsed time for occupied beds
   const occupiedBeds = beds.filter(b => b.isOccupied && b.elapsedTimeMs !== null)
   const averageElapsedTimeMs = occupiedBeds.length > 0
@@ -163,4 +163,26 @@ export function getBedStatistics(
     occupancyPercentage,
     averageElapsedTimeMs,
   }
+}
+
+const CRITICAL_STAGE_KEYWORDS = [
+  'discharge',
+  'code',
+  'critical',
+  'deceased',
+  'terminal',
+  'transfer'
+]
+
+/**
+ * Check if a stage is considered critical and requires confirmation
+ * @param stageName - Name of the stage
+ * @returns boolean
+ */
+export function isCriticalStage(stageName: string): boolean {
+  if (!stageName) return false
+  const normalizedStageName = stageName.toLowerCase()
+  return CRITICAL_STAGE_KEYWORDS.some(keyword =>
+    normalizedStageName.includes(keyword)
+  )
 }

--- a/src/features/bed-dashboard/types/bed.ts
+++ b/src/features/bed-dashboard/types/bed.ts
@@ -50,3 +50,20 @@ export interface BedGridData {
   stages: Stage[]
   delayThresholdMs: number
 }
+
+export interface OverrideState {
+  bedId: string
+  stageId: string
+  bedNumber: string
+  fromStageName: string | null
+  toStage: Stage
+  reason: string | null
+}
+
+export interface ConfirmationState {
+  bedId: string
+  stageId: string
+  bedNumber: string
+  fromStageName: string | null
+  toStage: Stage
+}


### PR DESCRIPTION
## Description
This PR adds a confirmation prompt before updating critical bed stages (including discharge).
When a nurse attempts to change a bed to a critical stage, a confirmation dialog appears displaying:
Bed number
Current stage
Target stage
Users must explicitly confirm the action using clearly distinguishable Yes/No buttons.
Keyboard shortcuts are supported:
Enter → Confirm
Escape → Cancel
Additionally, experienced users can disable confirmation prompts from settings.
This ensures safer stage updates and prevents accidental modifications.

## Linked Issue
Closes #20

## Type
<!-- Check one -->
- [ ] Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Refactor
- [ ] Test

### Code Quality
 No file exceeds 200 lines
 Code is properly formatted
 TypeScript types are properly defined
 No ESLint errors or warnings

### Testing
Tested locally and works as expected
 Added/updated tests if applicable
 All existing tests pass

### Database & Environment
-No database changes required

## Screenshots
<img width="1587" height="992" alt="Screenshot 2026-02-18 001214" src="https://github.com/user-attachments/assets/5264cca5-38b7-4864-b5fc-630a01fbd0d3" />

