### PR TITLE
feat: add shift schedule management admin UI and DB (#50)

### DIFF
--- a/migrations/015_create_shifts.sql
+++ b/migrations/015_create_shifts.sql
@@ -1,0 +1,34 @@
+-- Migration 015: Create Shifts Table (US-8.1)
+-- Purpose: Define shift schedules for shift-based data analysis
+-- Epic: EPIC 8 - Shift Management
+
+-- Up Migration
+
+CREATE TABLE IF NOT EXISTS shifts (
+    id           UUID         PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name         VARCHAR(100) NOT NULL UNIQUE,
+    start_time   TIME         NOT NULL,
+    end_time     TIME         NOT NULL,
+    is_default   BOOLEAN      NOT NULL DEFAULT false,
+    is_active    BOOLEAN      NOT NULL DEFAULT true,
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_shifts_active  ON shifts(is_active);
+CREATE INDEX IF NOT EXISTS idx_shifts_default ON shifts(is_default);
+
+COMMENT ON TABLE  shifts            IS 'Shift schedules used to tag bed status updates. Supports overlap for transition periods.';
+COMMENT ON COLUMN shifts.start_time IS 'Wall-clock start time (HH:MM). For Night shift this may be > end_time (wraps midnight).';
+COMMENT ON COLUMN shifts.end_time   IS 'Wall-clock end time (HH:MM). If < start_time, the shift crosses midnight.';
+COMMENT ON COLUMN shifts.is_default IS 'Default shifts (Morning, Evening, Night) are protected from deletion.';
+
+-- Insert default shifts (AC: Morning 6am-2pm, Evening 2pm-10pm, Night 10pm-6am)
+INSERT INTO shifts (name, start_time, end_time, is_default) VALUES
+    ('Morning', '06:00', '14:00', true),
+    ('Evening', '14:00', '22:00', true),
+    ('Night',   '22:00', '06:00', true)
+ON CONFLICT (name) DO NOTHING;
+
+-- Down Migration
+-- DROP TABLE IF EXISTS shifts;

--- a/migrations/016_add_shift_id_to_logs.sql
+++ b/migrations/016_add_shift_id_to_logs.sql
@@ -1,0 +1,43 @@
+-- Migration 016: Add shift_id to bed_stage_logs and patient_admissions (US-8.2)
+-- Purpose: Tag every stage transition and patient discharge with the active shift
+-- Epic: EPIC 8 - Shift Management
+
+-- Up Migration
+
+-- shifts table must exist (created in migration 015)
+
+-- Add shift_id to bed_stage_logs (nullable for backwards-compatibility with pre-migration rows)
+ALTER TABLE bed_stage_logs
+    ADD COLUMN IF NOT EXISTS shift_id
+        UUID REFERENCES shifts(id) ON DELETE SET NULL;
+
+-- Supervisor can manually override the auto-resolved shift (US-8.2 AC-4)
+ALTER TABLE bed_stage_logs
+    ADD COLUMN IF NOT EXISTS shift_override_by_user_id
+        UUID REFERENCES users(id) ON DELETE SET NULL;
+
+-- Index for shift-based filtering / analytics
+CREATE INDEX IF NOT EXISTS idx_bed_stage_logs_shift_id
+    ON bed_stage_logs(shift_id);
+
+-- Tag patient admissions so discharge reports can be filtered by shift
+ALTER TABLE patient_admissions
+    ADD COLUMN IF NOT EXISTS shift_id
+        UUID REFERENCES shifts(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_patient_admissions_shift_id
+    ON patient_admissions(shift_id);
+
+COMMENT ON COLUMN bed_stage_logs.shift_id IS
+    'Auto-resolved shift at transition time. NULL = pre-migration row or no active shift found.';
+
+COMMENT ON COLUMN bed_stage_logs.shift_override_by_user_id IS
+    'Supervisor who manually overrode the auto-resolved shift. NULL = system auto-tagged.';
+
+COMMENT ON COLUMN patient_admissions.shift_id IS
+    'Shift active at discharge time. NULL = pre-migration row.';
+
+-- Down Migration
+-- ALTER TABLE bed_stage_logs DROP COLUMN IF EXISTS shift_id;
+-- ALTER TABLE bed_stage_logs DROP COLUMN IF EXISTS shift_override_by_user_id;
+-- ALTER TABLE patient_admissions DROP COLUMN IF EXISTS shift_id;

--- a/migrations/017_create_system_settings.sql
+++ b/migrations/017_create_system_settings.sql
@@ -1,0 +1,18 @@
+-- Migration 017: System Settings table for US-6.3 (Set Time Thresholds)
+-- Stores global key-value configuration including delay_threshold_minutes
+
+CREATE TABLE IF NOT EXISTS system_settings (
+  key         VARCHAR(100) PRIMARY KEY,
+  value       TEXT         NOT NULL,
+  description TEXT,
+  updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- Default global delay threshold: 3 hours = 180 minutes
+INSERT INTO system_settings (key, value, description)
+VALUES (
+  'delay_threshold_minutes',
+  '180',
+  'Global delay threshold in minutes. Beds exceeding this time are flagged as delayed.'
+)
+ON CONFLICT (key) DO NOTHING;

--- a/migrations/017_create_system_settings.sql
+++ b/migrations/017_create_system_settings.sql
@@ -16,3 +16,6 @@ VALUES (
   'Global delay threshold in minutes. Beds exceeding this time are flagged as delayed.'
 )
 ON CONFLICT (key) DO NOTHING;
+
+-- Down Migration
+-- DROP TABLE IF EXISTS system_settings;

--- a/migrations/018_create_stage_delay_thresholds.sql
+++ b/migrations/018_create_stage_delay_thresholds.sql
@@ -1,0 +1,11 @@
+-- Migration 018: Per-stage delay thresholds for US-6.3 (advanced AC-3)
+-- Allows individual stages to override the global delay threshold
+
+CREATE TABLE IF NOT EXISTS stage_delay_thresholds (
+  stage_id          UUID  PRIMARY KEY REFERENCES stages(id) ON DELETE CASCADE,
+  threshold_minutes INT   NOT NULL CHECK (threshold_minutes > 0),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_stage_delay_thresholds_stage_id
+  ON stage_delay_thresholds(stage_id);

--- a/migrations/018_create_stage_delay_thresholds.sql
+++ b/migrations/018_create_stage_delay_thresholds.sql
@@ -9,3 +9,6 @@ CREATE TABLE IF NOT EXISTS stage_delay_thresholds (
 
 CREATE INDEX IF NOT EXISTS idx_stage_delay_thresholds_stage_id
   ON stage_delay_thresholds(stage_id);
+
+-- Down Migration
+-- DROP TABLE IF EXISTS stage_delay_thresholds;

--- a/src/app/admin/_components/AdminQuickActions.tsx
+++ b/src/app/admin/_components/AdminQuickActions.tsx
@@ -1,0 +1,92 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/shared/components/ui/card"
+import { Bed, BarChart3, Clock, Layers } from "lucide-react"
+import Link from "next/link"
+
+export function AdminQuickActions() {
+    return (
+        <Card className="bg-zinc-900 border-zinc-800">
+            <CardHeader>
+                <CardTitle className="text-xl text-white">Quick Actions</CardTitle>
+                <p className="text-sm text-zinc-400 mt-1">
+                    Manage system resources
+                </p>
+            </CardHeader>
+            <CardContent>
+                <div className="grid gap-4 md:grid-cols-2">
+                    <Link
+                        href="/admin/beds"
+                        className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
+                    >
+                        <div className="flex items-start gap-3">
+                            <div className="p-2 bg-blue-900/20 border border-blue-900/50 rounded-lg group-hover:bg-blue-900/30 transition-colors">
+                                <Bed className="h-5 w-5 text-blue-500" />
+                            </div>
+                            <div>
+                                <h3 className="font-semibold text-white group-hover:text-blue-400 transition-colors">
+                                    Manage Beds
+                                </h3>
+                                <p className="text-sm text-zinc-500 mt-1">
+                                    Add, edit, and manage hospital beds
+                                </p>
+                            </div>
+                        </div>
+                    </Link>
+                    <Link
+                        href="/analytics"
+                        className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
+                    >
+                        <div className="flex items-start gap-3">
+                            <div className="p-2 bg-emerald-900/20 border border-emerald-900/50 rounded-lg group-hover:bg-emerald-900/30 transition-colors">
+                                <BarChart3 className="h-5 w-5 text-emerald-500" />
+                            </div>
+                            <div>
+                                <h3 className="font-semibold text-white group-hover:text-emerald-400 transition-colors">
+                                    Ward Analytics
+                                </h3>
+                                <p className="text-sm text-zinc-500 mt-1">
+                                    Stage flow and turnaround time analytics
+                                </p>
+                            </div>
+                        </div>
+                    </Link>
+                    <Link
+                        href="/admin/stages"
+                        className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
+                    >
+                        <div className="flex items-start gap-3">
+                            <div className="p-2 bg-purple-900/20 border border-purple-900/50 rounded-lg group-hover:bg-purple-900/30 transition-colors">
+                                <Layers className="h-5 w-5 text-purple-500" />
+                            </div>
+                            <div>
+                                <h3 className="font-semibold text-white group-hover:text-purple-400 transition-colors">
+                                    Manage Stages
+                                </h3>
+                                <p className="text-sm text-zinc-500 mt-1">
+                                    Configure patient workflow stages
+                                </p>
+                            </div>
+                        </div>
+                    </Link>
+                    <Link
+                        href="/admin/shifts"
+                        className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
+                    >
+                        <div className="flex items-start gap-3">
+                            <div className="p-2 bg-emerald-900/20 border border-emerald-900/50 rounded-lg group-hover:bg-emerald-900/30 transition-colors">
+                                <Clock className="h-5 w-5 text-emerald-500" />
+                            </div>
+                            <div>
+                                <h3 className="font-semibold text-white group-hover:text-emerald-400 transition-colors">
+                                    Shift Schedules
+                                </h3>
+                                <p className="text-sm text-zinc-500 mt-1">
+                                    Configure Morning, Evening &amp; Night shifts
+                                </p>
+                            </div>
+                        </div>
+                    </Link>
+                </div>
+            </CardContent>
+        </Card>
+    )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,9 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/components/ui/card"
-import { Shield, Users, Settings, Activity, Bed, BarChart3, Clock, Layers } from "lucide-react"
+import { Shield, Users, Settings, Activity } from "lucide-react"
 import { LogoutButton } from "@/features/auth/components/LogoutButton"
 import { redirect } from "next/navigation"
-import Link from "next/link"
 import { AdminRecentActivity } from './AdminRecentActivity'
+import { AdminQuickActions } from "./_components/AdminQuickActions"
 
 import { verifyActiveSession } from "@/shared/lib/active-session"
 import { getAllUsers, getUserLogs } from "@/features/user-management/actions/user-management-actions"
@@ -88,89 +88,7 @@ export default async function AdminDashboard() {
                     </Card>
                 </div>
 
-                {/* Quick Actions */}
-                <Card className="bg-zinc-900 border-zinc-800">
-                    <CardHeader>
-                        <CardTitle className="text-xl text-white">Quick Actions</CardTitle>
-                        <p className="text-sm text-zinc-400 mt-1">Manage system resources</p>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="grid gap-4 md:grid-cols-2">
-                            <Link
-                                href="/admin/beds"
-                                className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
-                            >
-                                <div className="flex items-start gap-3">
-                                    <div className="p-2 bg-blue-900/20 border border-blue-900/50 rounded-lg group-hover:bg-blue-900/30 transition-colors">
-                                        <Bed className="h-5 w-5 text-blue-500" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-semibold text-white group-hover:text-blue-400 transition-colors">
-                                            Manage Beds
-                                        </h3>
-                                        <p className="text-sm text-zinc-500 mt-1">
-                                            Add, edit, and manage hospital beds
-                                        </p>
-                                    </div>
-                                </div>
-                            </Link>
-                            <Link
-                                href="/analytics"
-                                className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
-                            >
-                                <div className="flex items-start gap-3">
-                                    <div className="p-2 bg-emerald-900/20 border border-emerald-900/50 rounded-lg group-hover:bg-emerald-900/30 transition-colors">
-                                        <BarChart3 className="h-5 w-5 text-emerald-500" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-semibold text-white group-hover:text-emerald-400 transition-colors">
-                                            Ward Analytics
-                                        </h3>
-                                        <p className="text-sm text-zinc-500 mt-1">
-                                            Stage flow and turnaround time analytics
-                                        </p>
-                                    </div>
-                                </div>
-                            </Link>
-                            <Link
-                                href="/admin/stages"
-                                className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
-                            >
-                                <div className="flex items-start gap-3">
-                                    <div className="p-2 bg-purple-900/20 border border-purple-900/50 rounded-lg group-hover:bg-purple-900/30 transition-colors">
-                                        <Layers className="h-5 w-5 text-purple-500" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-semibold text-white group-hover:text-purple-400 transition-colors">
-                                            Manage Stages
-                                        </h3>
-                                        <p className="text-sm text-zinc-500 mt-1">
-                                            Configure patient workflow stages
-                                        </p>
-                                    </div>
-                                </div>
-                            </Link>
-                            <Link
-                                href="/admin/shifts"
-                                className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
-                            >
-                                <div className="flex items-start gap-3">
-                                    <div className="p-2 bg-teal-900/20 border border-teal-900/50 rounded-lg group-hover:bg-teal-900/30 transition-colors">
-                                        <Clock className="h-5 w-5 text-teal-500" />
-                                    </div>
-                                    <div>
-                                        <h3 className="font-semibold text-white group-hover:text-teal-400 transition-colors">
-                                            Shift Schedules
-                                        </h3>
-                                        <p className="text-sm text-zinc-500 mt-1">
-                                            Configure Morning, Evening &amp; Night shifts
-                                        </p>
-                                    </div>
-                                </div>
-                            </Link>
-                        </div>
-                    </CardContent>
-                </Card>
+                <AdminQuickActions />
 
                 {/* User Management Section */}
                 <Card className="bg-zinc-900 border-zinc-800">

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/shared/components/ui/card"
-import { Shield, Users, Settings, Activity, Bed, BarChart3 } from "lucide-react"
+import { Shield, Users, Settings, Activity, Bed, BarChart3, Clock, Layers } from "lucide-react"
 import { LogoutButton } from "@/features/auth/components/LogoutButton"
 import { redirect } from "next/navigation"
 import Link from "next/link"
@@ -128,6 +128,42 @@ export default async function AdminDashboard() {
                                         </h3>
                                         <p className="text-sm text-zinc-500 mt-1">
                                             Stage flow and turnaround time analytics
+                                        </p>
+                                    </div>
+                                </div>
+                            </Link>
+                            <Link
+                                href="/admin/stages"
+                                className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
+                            >
+                                <div className="flex items-start gap-3">
+                                    <div className="p-2 bg-purple-900/20 border border-purple-900/50 rounded-lg group-hover:bg-purple-900/30 transition-colors">
+                                        <Layers className="h-5 w-5 text-purple-500" />
+                                    </div>
+                                    <div>
+                                        <h3 className="font-semibold text-white group-hover:text-purple-400 transition-colors">
+                                            Manage Stages
+                                        </h3>
+                                        <p className="text-sm text-zinc-500 mt-1">
+                                            Configure patient workflow stages
+                                        </p>
+                                    </div>
+                                </div>
+                            </Link>
+                            <Link
+                                href="/admin/shifts"
+                                className="p-4 rounded-lg bg-black/30 border border-zinc-800 hover:border-zinc-700 hover:bg-black/50 transition-all group"
+                            >
+                                <div className="flex items-start gap-3">
+                                    <div className="p-2 bg-teal-900/20 border border-teal-900/50 rounded-lg group-hover:bg-teal-900/30 transition-colors">
+                                        <Clock className="h-5 w-5 text-teal-500" />
+                                    </div>
+                                    <div>
+                                        <h3 className="font-semibold text-white group-hover:text-teal-400 transition-colors">
+                                            Shift Schedules
+                                        </h3>
+                                        <p className="text-sm text-zinc-500 mt-1">
+                                            Configure Morning, Evening &amp; Night shifts
                                         </p>
                                     </div>
                                 </div>

--- a/src/app/admin/shifts/page.tsx
+++ b/src/app/admin/shifts/page.tsx
@@ -1,0 +1,26 @@
+// Admin: Shift Schedules Page (US-8.1)
+// Epic 8: Shift Management
+
+import { getAllShifts } from '@/features/shift-management/lib/shift-queries'
+import { ShiftList } from '@/features/shift-management/components/ShiftList'
+
+// Force dynamic rendering — prevents build-time DB connection errors
+export const dynamic = 'force-dynamic'
+
+export default async function ShiftsPage() {
+  const shifts = await getAllShifts()
+
+  return (
+    <div className='p-6 max-w-2xl mx-auto'>
+      <div className='mb-6'>
+        <h1 className='text-2xl font-bold'>Shift Schedules</h1>
+        <p className='text-gray-500 text-sm mt-1'>
+          Configure Morning, Evening, and Night shifts. Default shifts cannot be deleted.
+          Shifts can overlap for transition periods. Each bed status update is automatically
+          tagged with the active shift.
+        </p>
+      </div>
+      <ShiftList initialShifts={shifts} />
+    </div>
+  )
+}

--- a/src/app/admin/stages/page.tsx
+++ b/src/app/admin/stages/page.tsx
@@ -1,12 +1,17 @@
 import { getStages } from '@/features/stage-management/actions/stage-actions';
 import { StageList } from '@/features/stage-management/components/StageList';
+import { GlobalThresholdForm } from '@/features/stage-management/components/GlobalThresholdForm';
+import { getGlobalThresholdMinutes } from '@/shared/lib/threshold';
 
 // Force dynamic rendering - don't pre-render during build
 // This prevents build-time errors when database connection requires specific env config
 export const dynamic = 'force-dynamic';
 
 export default async function StagesPage() {
-  const stages = await getStages();
+  const [stages, globalThresholdMinutes] = await Promise.all([
+    getStages(),
+    getGlobalThresholdMinutes(),
+  ]);
   return (
     <div className='p-6 max-w-2xl mx-auto'>
       <div className='mb-6'>
@@ -15,6 +20,7 @@ export default async function StagesPage() {
           Default stages cannot be deleted. You can add, edit, delete and reorder custom stages.
         </p>
       </div>
+      <GlobalThresholdForm initialMinutes={globalThresholdMinutes} />
       <StageList initialStages={stages} />
     </div>
   );

--- a/src/features/bed-dashboard/actions/bed-actions.ts
+++ b/src/features/bed-dashboard/actions/bed-actions.ts
@@ -111,11 +111,16 @@ export async function updateBedStage(input: UpdateBedStageInput): Promise<{
     }
 
     // Proceed with update
+    // US-8.2: Pass shift override fields — supervisor can tag the log with a specific
+    // shift instead of the auto-resolved one (e.g. during shift handover).
+    const canOverrideShift = session.role === 'supervisor' || session.role === 'admin'
     const updateResult = await updateBedStageInDB({
       bedId: result.data.bedId,
       toStageId: result.data.toStageId,
       changedByUserId: session.userId,
       notes: result.data.notes,
+      shiftOverrideId: canOverrideShift ? (result.data.shiftOverrideId ?? null) : null,
+      shiftOverrideByUserId: canOverrideShift && result.data.shiftOverrideId ? session.userId : null,
     })
 
     // BUG FIX #7: Log audit AFTER update with error handling

--- a/src/features/bed-dashboard/actions/bed-grid-actions.ts
+++ b/src/features/bed-dashboard/actions/bed-grid-actions.ts
@@ -1,12 +1,12 @@
 'use server'
 
 import { getAllStages, getBedsWithElapsedTime, getBedById } from '../lib/queries'
-import { config } from '@/shared/config/env'
 import { logger } from '@/shared/config/logger'
 import type { BedGridData } from '../types/bed'
 import { getUserWard, getBedWard } from '../lib/bed-queries'
 import { requireRole } from '@/shared/lib/auth'
 import { categorizeStagesForTransition } from '../lib/stage-validation'
+import { getGlobalThresholdMs } from '@/shared/lib/threshold'
 
 /**
  * Get all beds with current status and elapsed time
@@ -23,7 +23,7 @@ export async function getBedGridData(): Promise<{
 
     logger.info('Fetching bed grid data')
 
-    const delayThresholdMs = config.alert.delayThresholdMs
+    const delayThresholdMs = await getGlobalThresholdMs()
 
     // Fetch beds and stages in parallel
     const [beds, stages] = await Promise.all([
@@ -69,7 +69,7 @@ export async function getDelayedBeds(): Promise<{
   error?: string
 }> {
   try {
-    const delayThresholdMs = config.alert.delayThresholdMs
+    const delayThresholdMs = await getGlobalThresholdMs()
     const allBeds = await getBedsWithElapsedTime(delayThresholdMs)
     const delayedBeds = allBeds.filter(bed => bed.isDelayed)
 

--- a/src/features/bed-dashboard/lib/bed-bottleneck-queries.ts
+++ b/src/features/bed-dashboard/lib/bed-bottleneck-queries.ts
@@ -42,10 +42,16 @@ export async function getBedsWithElapsedTime(
           THEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - b.patient_start_time)) * 1000
           ELSE NULL
         END                                   AS "elapsedTimeMs",
-        -- Flag overall delay (> configurable threshold, default 3 h)
+        -- Flag overall delay (> per-stage threshold if set, else global — US-6.3)
         CASE
           WHEN b.is_occupied AND b.patient_start_time IS NOT NULL
-            AND EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - b.patient_start_time)) * 1000 > $1
+            AND EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - b.patient_start_time)) * 1000
+              > COALESCE(
+                  (SELECT sdt.threshold_minutes * 60000.0
+                   FROM stage_delay_thresholds sdt
+                   WHERE sdt.stage_id = b.current_stage_id),
+                  $1
+                )
           THEN true
           ELSE false
         END                                   AS "isDelayed",

--- a/src/features/bed-dashboard/lib/bed-mutations.ts
+++ b/src/features/bed-dashboard/lib/bed-mutations.ts
@@ -1,5 +1,6 @@
 // Bed Dashboard Mutations
 // Epic 2: One-Click Stage Update System
+// US-8.2: Auto-tag each stage transition with the active shift
 
 import pool from '@/shared/lib/db'
 import { logger } from '@/shared/config/logger'
@@ -22,6 +23,10 @@ export interface UpdateBedStageParams {
   toStageId: string
   changedByUserId: string
   notes?: string
+  /** US-8.2: Supervisor manually overrides the auto-resolved shift for this log entry */
+  shiftOverrideId?: string | null
+  /** User ID of the supervisor performing the override */
+  shiftOverrideByUserId?: string | null
 }
 
 export interface UpdateBedStageResult {
@@ -43,7 +48,7 @@ function isNonPatientStage(stageName: string): boolean {
 export async function updateBedStageInDB(
   params: UpdateBedStageParams
 ): Promise<UpdateBedStageResult> {
-  const { bedId, toStageId, changedByUserId, notes } = params
+  const { bedId, toStageId, changedByUserId, notes, shiftOverrideId, shiftOverrideByUserId } = params
   const client = await pool.connect()
 
   try {
@@ -120,6 +125,9 @@ export async function updateBedStageInDB(
       [toStageId, shouldBeUnoccupied, nextIsOccupied, bedId]
     )
 
+    // US-8.2: Auto-tag shift_id using an inline subquery that correctly handles
+    // midnight-crossing shifts (e.g. Night: 22:00–06:00 where start_time > end_time).
+    // If a supervisor-provided shiftOverrideId is passed, that takes precedence.
     await client.query(
       `
       INSERT INTO bed_stage_logs (
@@ -128,8 +136,33 @@ export async function updateBedStageInDB(
         to_stage_id,
         changed_by_user_id,
         duration_in_previous_stage_ms,
-        notes
-      ) VALUES ($1, $2, $3, $4, $5, $6)
+        notes,
+        shift_id,
+        shift_override_by_user_id
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6,
+        COALESCE(
+          $7::uuid,
+          (
+            SELECT s.id
+            FROM   shifts s
+            WHERE  s.is_active = TRUE
+              AND (
+                -- Normal shift: start_time <= end_time
+                (s.start_time <= s.end_time
+                   AND NOW()::time >= s.start_time
+                   AND NOW()::time <  s.end_time)
+                OR
+                -- Midnight-crossing shift: start_time > end_time
+                (s.start_time > s.end_time
+                   AND (NOW()::time >= s.start_time OR NOW()::time < s.end_time))
+              )
+            ORDER BY s.is_default DESC, s.created_at ASC
+            LIMIT 1
+          )
+        ),
+        $8::uuid
+      )
       `,
       [
         bedId,
@@ -138,6 +171,8 @@ export async function updateBedStageInDB(
         changedByUserId,
         durationInPreviousStageMs,
         notes || null,
+        shiftOverrideId ?? null,
+        shiftOverrideByUserId ?? null,
       ]
     )
 

--- a/src/features/bed-dashboard/schemas/bed-schemas.ts
+++ b/src/features/bed-dashboard/schemas/bed-schemas.ts
@@ -41,6 +41,8 @@ export const UpdateBedStageSchema = z.object({
   supervisorOverride: z.boolean().optional().default(false),
   overrideReason: z.string().max(500).optional(),
   notes: z.string().max(500).optional(),
+  /** US-8.2: Supervisor-provided shift ID to override auto-resolution for this log entry */
+  shiftOverrideId: z.string().uuid('Invalid shift ID').optional().nullable(),
 })
 
 export type CreateBedInput = z.infer<typeof CreateBedSchema>

--- a/src/features/shift-management/actions/shift-actions.ts
+++ b/src/features/shift-management/actions/shift-actions.ts
@@ -1,0 +1,120 @@
+'use server'
+// Shift CRUD Server Actions (US-8.1)
+// Epic 8: Shift Management
+
+import { query } from '@/shared/lib/db'
+import { revalidatePath } from 'next/cache'
+import { requireRole } from '@/shared/lib/auth'
+import { logAudit } from '@/shared/lib/audit'
+import { logger } from '@/shared/config/logger'
+import { CreateShiftSchema, UpdateShiftSchema } from '../schemas/shift-schemas'
+import { getAllShifts } from '../lib/shift-queries'
+import type { Shift } from '../types/shift.types'
+
+export async function getShiftsAction(): Promise<{
+  success: boolean
+  shifts?: Shift[]
+  error?: string
+}> {
+  try {
+    const shifts = await getAllShifts()
+    return { success: true, shifts }
+  } catch (err) {
+    logger.error('getShiftsAction failed', err as Error)
+    return { success: false, error: 'Failed to load shifts' }
+  }
+}
+
+export async function createShift(input: {
+  name: string
+  start_time: string
+  end_time: string
+}): Promise<{ success: boolean; shift?: Shift; error?: string }> {
+  try {
+    const session = await requireRole(['admin'])
+    const parsed = CreateShiftSchema.safeParse(input)
+    if (!parsed.success) {
+      const firstError = Object.values(parsed.error.flatten().fieldErrors)[0]?.[0]
+      return { success: false, error: firstError ?? 'Validation error' }
+    }
+    const { name, start_time, end_time } = parsed.data
+    const result = await query<Shift>(
+      `INSERT INTO shifts (name, start_time, end_time, is_default)
+       VALUES ($1, $2::time, $3::time, false)
+       RETURNING id, name,
+         start_time::text AS start_time, end_time::text AS end_time,
+         (start_time > end_time) AS crosses_midnight,
+         is_default, is_active,
+         created_at::text AS created_at, updated_at::text AS updated_at`,
+      [name.trim(), start_time, end_time]
+    )
+    const shift = result.rows[0]
+    await logAudit({ actionType: 'CREATE', entityType: 'shift', entityId: shift.id,
+      performedBy: session.userId, changes: { name, start_time, end_time } })
+    logger.info('Shift created', { shiftId: shift.id, name, performedBy: session.userId })
+    revalidatePath('/admin/shifts')
+    return { success: true, shift }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create shift'
+    logger.error('createShift failed', err as Error)
+    return { success: false, error: message }
+  }
+}
+
+export async function updateShift(input: {
+  id: string; name?: string; start_time?: string; end_time?: string; is_active?: boolean
+}): Promise<{ success: boolean; shift?: Shift; error?: string }> {
+  try {
+    const session = await requireRole(['admin'])
+    const parsed = UpdateShiftSchema.safeParse(input)
+    if (!parsed.success) {
+      const firstError = Object.values(parsed.error.flatten().fieldErrors)[0]?.[0]
+      return { success: false, error: firstError ?? 'Validation error' }
+    }
+    const { id, name, start_time, end_time, is_active } = parsed.data
+    const result = await query<Shift>(
+      `UPDATE shifts
+       SET name = COALESCE($1, name), start_time = COALESCE($2::time, start_time),
+           end_time = COALESCE($3::time, end_time), is_active = COALESCE($4, is_active),
+           updated_at = NOW()
+       WHERE id = $5
+       RETURNING id, name,
+         start_time::text AS start_time, end_time::text AS end_time,
+         (start_time > end_time) AS crosses_midnight,
+         is_default, is_active,
+         created_at::text AS created_at, updated_at::text AS updated_at`,
+      [name?.trim() ?? null, start_time ?? null, end_time ?? null, is_active ?? null, id]
+    )
+    if (result.rows.length === 0) return { success: false, error: 'Shift not found' }
+    const shift = result.rows[0]
+    await logAudit({ actionType: 'UPDATE', entityType: 'shift', entityId: id,
+      performedBy: session.userId, changes: { name, start_time, end_time, is_active } })
+    logger.info('Shift updated', { shiftId: id, performedBy: session.userId })
+    revalidatePath('/admin/shifts')
+    return { success: true, shift }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update shift'
+    logger.error('updateShift failed', err as Error)
+    return { success: false, error: message }
+  }
+}
+
+export async function deleteShift(id: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await requireRole(['admin'])
+    const result = await query(
+      `UPDATE shifts SET is_active = FALSE, updated_at = NOW()
+       WHERE id = $1 AND is_default = FALSE RETURNING id`,
+      [id]
+    )
+    if (result.rowCount === 0) return { success: false, error: 'Default shifts cannot be deleted' }
+    await logAudit({ actionType: 'DEACTIVATE', entityType: 'shift', entityId: id,
+      performedBy: session.userId, changes: {} })
+    logger.info('Shift deactivated', { shiftId: id, performedBy: session.userId })
+    revalidatePath('/admin/shifts')
+    return { success: true }
+  } catch (err) {
+    logger.error('deleteShift failed', err as Error)
+    return { success: false, error: 'Failed to delete shift' }
+  }
+}

--- a/src/features/shift-management/actions/shift-override-actions.ts
+++ b/src/features/shift-management/actions/shift-override-actions.ts
@@ -1,0 +1,52 @@
+'use server'
+// Shift Override Server Action (US-8.2 AC-4)
+// Epic 8: Shift Management
+//
+// Allows a supervisor or admin to manually reassign the shift tag on an
+// existing bed_stage_log entry — e.g. during shift handover disputes.
+
+import { query } from '@/shared/lib/db'
+import { revalidatePath } from 'next/cache'
+import { requireRole } from '@/shared/lib/auth'
+import { logAudit } from '@/shared/lib/audit'
+import { logger } from '@/shared/config/logger'
+
+/**
+ * Supervisor manually reassigns the shift on a bed stage log entry.
+ * Sets shift_id and records which supervisor performed the override.
+ */
+export async function overrideLogShift(input: {
+  logId: string
+  shiftId: string
+}): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await requireRole(['supervisor', 'admin'])
+
+    await query(
+      `UPDATE bed_stage_logs
+       SET shift_id = $1,
+           shift_override_by_user_id = $2
+       WHERE id = $3`,
+      [input.shiftId, session.userId, input.logId]
+    )
+
+    await logAudit({
+      actionType: 'UPDATE',
+      entityType: 'bed_stage_log_shift',
+      entityId: input.logId,
+      performedBy: session.userId,
+      changes: { shiftId: input.shiftId },
+    })
+
+    logger.info('Log shift overridden', {
+      logId: input.logId,
+      shiftId: input.shiftId,
+      by: session.userId,
+    })
+    revalidatePath('/dashboard')
+    return { success: true }
+  } catch (err) {
+    logger.error('overrideLogShift failed', err as Error)
+    return { success: false, error: 'Failed to override shift' }
+  }
+}

--- a/src/features/shift-management/components/ShiftFormDialog.tsx
+++ b/src/features/shift-management/components/ShiftFormDialog.tsx
@@ -1,0 +1,148 @@
+'use client'
+// ShiftFormDialog — Create / Edit Shift (US-8.1)
+// Epic 8: Shift Management
+
+import { useState } from 'react'
+import type { Shift } from '../types/shift.types'
+import { createShift, updateShift } from '../actions/shift-actions'
+import { formatShiftTime } from '../lib/shift-format'
+
+interface Props {
+  shift?: Shift
+  onClose: () => void
+  onSaved: (shift: Shift) => void
+}
+
+/** Strip seconds from "HH:MM:SS" → "HH:MM" for the time input value */
+function toInputTime(t?: string): string {
+  if (!t) return ''
+  return t.slice(0, 5)
+}
+
+/** Describe whether the shift crosses midnight */
+function midnightNote(start: string, end: string): string | null {
+  if (!start || !end) return null
+  return start > end ? '⚠ This shift crosses midnight (e.g. 22:00 – 06:00).' : null
+}
+
+export function ShiftFormDialog({ shift, onClose, onSaved }: Props) {
+  const [name, setName]       = useState(shift?.name ?? '')
+  const [start, setStart]     = useState(toInputTime(shift?.start_time))
+  const [end, setEnd]         = useState(toInputTime(shift?.end_time))
+  const [error, setError]     = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const crossesMidnight = midnightNote(start, end)
+
+  const handleSave = async () => {
+    if (!name.trim()) return setError('Shift name is required')
+    if (!start)       return setError('Start time is required')
+    if (!end)         return setError('End time is required')
+    if (start === end) return setError('Start and end time cannot be the same')
+
+    setLoading(true)
+    setError('')
+
+    try {
+      if (shift) {
+        const res = await updateShift({ id: shift.id, name, start_time: start, end_time: end })
+        if (!res.success || !res.shift) {
+          setError(res.error ?? 'Failed to update shift')
+          return
+        }
+        onSaved(res.shift)
+      } else {
+        const res = await createShift({ name, start_time: start, end_time: end })
+        if (!res.success || !res.shift) {
+          setError(res.error ?? 'Failed to create shift')
+          return
+        }
+        onSaved(res.shift)
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className='fixed inset-0 bg-black/60 flex items-center justify-center z-50'>
+      <div className='bg-white rounded-xl p-6 w-full max-w-md shadow-2xl'>
+
+        <h2 className='text-xl font-bold text-gray-900 mb-4'>
+          {shift ? 'Edit Shift' : 'Add New Shift'}
+        </h2>
+
+        {/* Name */}
+        <label className='block text-sm font-semibold text-gray-700 mb-1'>
+          Shift Name <span className='text-gray-400 font-normal'>({name.length}/100)</span>
+        </label>
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          maxLength={100}
+          disabled={shift?.is_default}
+          className='w-full border border-gray-300 rounded-lg px-3 py-2 mb-4 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:text-gray-500'
+          placeholder='e.g. Morning'
+        />
+
+        {/* Times */}
+        <div className='grid grid-cols-2 gap-4 mb-1'>
+          <div>
+            <label className='block text-sm font-semibold text-gray-700 mb-1'>Start Time</label>
+            <input
+              type='time'
+              value={start}
+              onChange={e => setStart(e.target.value)}
+              className='w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
+            />
+          </div>
+          <div>
+            <label className='block text-sm font-semibold text-gray-700 mb-1'>End Time</label>
+            <input
+              type='time'
+              value={end}
+              onChange={e => setEnd(e.target.value)}
+              className='w-full border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
+            />
+          </div>
+        </div>
+
+        {/* Preview */}
+        {start && end && (
+          <p className='text-xs text-gray-500 mb-1'>
+            Range: <span className='font-medium text-gray-700'>{formatShiftTime(start, end)}</span>
+          </p>
+        )}
+
+        {/* Midnight warning */}
+        {crossesMidnight && (
+          <p className='text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-2 py-1 mb-4'>
+            {crossesMidnight}
+          </p>
+        )}
+
+        {!crossesMidnight && <div className='mb-4' />}
+
+        {/* Error */}
+        {error && <p className='text-red-600 text-sm mb-3'>{error}</p>}
+
+        <div className='flex justify-end gap-3'>
+          <button
+            onClick={onClose}
+            className='px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-100'>
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={loading}
+            className='px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50'>
+            {loading ? 'Saving...' : 'Save Shift'}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/features/shift-management/components/ShiftList.tsx
+++ b/src/features/shift-management/components/ShiftList.tsx
@@ -1,0 +1,105 @@
+'use client'
+// ShiftList — Admin manage shifts (US-8.1)
+// Epic 8: Shift Management
+
+import { useState } from 'react'
+import type { Shift } from '../types/shift.types'
+import { deleteShift } from '../actions/shift-actions'
+import { ShiftFormDialog } from './ShiftFormDialog'
+import { formatShiftTime } from '../lib/shift-format'
+
+interface Props {
+  initialShifts: Shift[]
+}
+
+export function ShiftList({ initialShifts }: Props) {
+  const [shifts, setShifts]   = useState<Shift[]>(initialShifts)
+  const [editing, setEditing] = useState<Shift | null>(null)
+  const [showAdd, setShowAdd] = useState(false)
+
+  const handleDelete = async (shift: Shift) => {
+    if (!confirm(`Delete shift "${shift.name}"?`)) return
+    const res = await deleteShift(shift.id)
+    if (!res.success) {
+      alert(res.error ?? 'Failed to delete shift')
+      return
+    }
+    setShifts(prev => prev.filter(s => s.id !== shift.id))
+  }
+
+  return (
+    <div className='space-y-3'>
+      <button
+        onClick={() => setShowAdd(true)}
+        className='px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700'>
+        + Add New Shift
+      </button>
+
+      {shifts.length === 0 && (
+        <p className='text-gray-500 text-sm py-4'>No shifts configured.</p>
+      )}
+
+      {shifts.map(shift => (
+        <div
+          key={shift.id}
+          className='flex items-center justify-between p-4 rounded-lg border-2 border-zinc-700 bg-zinc-800'>
+
+          <div className='flex flex-col gap-0.5'>
+            <div className='flex items-center gap-3'>
+              <span className='font-semibold text-base text-white'>{shift.name}</span>
+              {shift.is_default && (
+                <span className='text-xs bg-zinc-900/60 px-2 py-0.5 rounded-full text-zinc-300 border border-zinc-600'>
+                  Default
+                </span>
+              )}
+              {!shift.is_active && (
+                <span className='text-xs bg-red-900/40 px-2 py-0.5 rounded-full text-red-400 border border-red-800'>
+                  Inactive
+                </span>
+              )}
+              {shift.crosses_midnight && (
+                <span className='text-xs bg-amber-900/30 px-2 py-0.5 rounded-full text-amber-400 border border-amber-800'>
+                  Crosses Midnight
+                </span>
+              )}
+            </div>
+            <span className='text-sm text-zinc-400 font-mono'>
+              {formatShiftTime(shift.start_time, shift.end_time)}
+            </span>
+          </div>
+
+          <div className='flex gap-2'>
+            <button
+              onClick={() => setEditing(shift)}
+              className='px-3 py-1 bg-white border border-gray-400 rounded text-gray-800 font-medium text-sm hover:bg-gray-100'>
+              Edit
+            </button>
+            {!shift.is_default && (
+              <button
+                onClick={() => handleDelete(shift)}
+                className='px-3 py-1 bg-red-500 border border-red-600 rounded text-white font-medium text-sm hover:bg-red-600'>
+                Delete
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+
+      {(showAdd || editing) && (
+        <ShiftFormDialog
+          shift={editing ?? undefined}
+          onClose={() => { setShowAdd(false); setEditing(null) }}
+          onSaved={(saved) => {
+            if (editing) {
+              setShifts(prev => prev.map(s => s.id === saved.id ? saved : s))
+            } else {
+              setShifts(prev => [...prev, saved])
+            }
+            setShowAdd(false)
+            setEditing(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/features/shift-management/lib/shift-format.ts
+++ b/src/features/shift-management/lib/shift-format.ts
@@ -1,0 +1,11 @@
+// Shift format helpers — pure functions, safe to import from client components
+// No database dependency.
+
+/**
+ * Format a shift's time range as a human-readable string.
+ * Accepts "HH:MM" or "HH:MM:SS".  e.g. "06:00 – 14:00"
+ */
+export function formatShiftTime(start: string, end: string): string {
+  const fmt = (t: string) => t.slice(0, 5) // "HH:MM"
+  return `${fmt(start)} – ${fmt(end)}`
+}

--- a/src/features/shift-management/lib/shift-queries.ts
+++ b/src/features/shift-management/lib/shift-queries.ts
@@ -1,0 +1,97 @@
+// Shift Management Queries (US-8.1)
+// Epic 8: Shift Management
+
+import { query } from '@/shared/lib/db'
+import type { Shift } from '../types/shift.types'
+
+// ---------------------------------------------------------------------------
+// Internal row type from PostgreSQL
+// ---------------------------------------------------------------------------
+
+interface ShiftRow {
+  id: string
+  name: string
+  start_time: string
+  end_time: string
+  crosses_midnight: boolean
+  is_default: boolean
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Return all active shifts ordered by start_time.
+ * Includes computed `crosses_midnight` flag for Night-shift handling.
+ */
+export async function getShifts(): Promise<Shift[]> {
+  const result = await query<ShiftRow>(
+    `
+    SELECT
+      id,
+      name,
+      start_time::text   AS start_time,
+      end_time::text     AS end_time,
+      (start_time > end_time) AS crosses_midnight,
+      is_default,
+      is_active,
+      created_at::text   AS created_at,
+      updated_at::text   AS updated_at
+    FROM shifts
+    WHERE is_active = TRUE
+    ORDER BY start_time ASC
+    `
+  )
+  return result.rows as Shift[]
+}
+
+/**
+ * Return a single shift by ID (active or inactive).
+ */
+export async function getShiftById(id: string): Promise<Shift | null> {
+  const result = await query<ShiftRow>(
+    `
+    SELECT
+      id,
+      name,
+      start_time::text   AS start_time,
+      end_time::text     AS end_time,
+      (start_time > end_time) AS crosses_midnight,
+      is_default,
+      is_active,
+      created_at::text   AS created_at,
+      updated_at::text   AS updated_at
+    FROM shifts
+    WHERE id = $1
+    `,
+    [id]
+  )
+  return result.rows[0] ?? null
+}
+
+/**
+ * Return all shifts (including inactive) — used by the admin page.
+ */
+export async function getAllShifts(): Promise<Shift[]> {
+  const result = await query<ShiftRow>(
+    `
+    SELECT
+      id,
+      name,
+      start_time::text   AS start_time,
+      end_time::text     AS end_time,
+      (start_time > end_time) AS crosses_midnight,
+      is_default,
+      is_active,
+      created_at::text   AS created_at,
+      updated_at::text   AS updated_at
+    FROM shifts
+    ORDER BY start_time ASC
+    `
+  )
+  return result.rows as Shift[]
+}

--- a/src/features/shift-management/lib/shift-utils.ts
+++ b/src/features/shift-management/lib/shift-utils.ts
@@ -1,0 +1,77 @@
+// Shift Resolution Utility (US-8.2)
+// Epic 8: Shift Management
+//
+// Resolves which shift is active at a given wall-clock time.
+// Handles the Night shift that crosses midnight (start_time > end_time).
+//
+// SERVER-ONLY: this module imports pg (Node.js). Never import from client components.
+import 'server-only'
+
+import { query } from '@/shared/lib/db'
+import type { Shift } from '../types/shift.types'
+
+interface ShiftRow {
+  id: string
+  name: string
+  start_time: string
+  end_time: string
+  crosses_midnight: boolean
+  is_default: boolean
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Resolve the active shift for a given timestamp (defaults to NOW).
+ *
+ * Logic:
+ *  - Normal shift  (start < end):  active when  start <= t < end
+ *  - Midnight-wrap (start > end):  active when  t >= start  OR  t < end
+ *
+ * When multiple shifts match (overlapping transition periods), the default
+ * shift wins; ties are broken by earliest created_at.
+ *
+ * Returns null if no shift covers the given time.
+ */
+export async function resolveCurrentShift(at?: Date): Promise<Shift | null> {
+  const t = at ?? new Date()
+  // Extract HH:MM:SS from the local wall-clock time as a PostgreSQL TIME literal
+  const hh  = t.getHours().toString().padStart(2, '0')
+  const mm  = t.getMinutes().toString().padStart(2, '0')
+  const ss  = t.getSeconds().toString().padStart(2, '0')
+  const timeStr = `${hh}:${mm}:${ss}`
+
+  const result = await query<ShiftRow>(
+    `
+    SELECT
+      id,
+      name,
+      start_time::text   AS start_time,
+      end_time::text     AS end_time,
+      (start_time > end_time) AS crosses_midnight,
+      is_default,
+      is_active,
+      created_at::text   AS created_at,
+      updated_at::text   AS updated_at
+    FROM shifts
+    WHERE is_active = TRUE
+      AND (
+        -- Normal shift: start_time <= query_time < end_time
+        (start_time <= end_time AND $1::time >= start_time AND $1::time < end_time)
+        OR
+        -- Midnight-crossing shift: query_time >= start OR query_time < end
+        (start_time > end_time  AND ($1::time >= start_time OR $1::time < end_time))
+      )
+    ORDER BY is_default DESC, created_at ASC
+    LIMIT 1
+    `,
+    [timeStr]
+  )
+
+  if (result.rows.length === 0) return null
+  return result.rows[0] as Shift
+}
+
+// formatShiftTime has moved to ./shift-format.ts (client-safe pure helper).
+export { formatShiftTime } from './shift-format'

--- a/src/features/shift-management/schemas/shift-schemas.ts
+++ b/src/features/shift-management/schemas/shift-schemas.ts
@@ -1,0 +1,29 @@
+// Shift Management Validation Schemas (US-8.1)
+// Epic 8: Shift Management
+
+import { z } from 'zod'
+
+/** Accepts "HH:MM" or "HH:MM:SS" from both forms and PostgreSQL TIME columns */
+const TimeSchema = z
+  .string()
+  .regex(/^\d{2}:\d{2}(:\d{2})?$/, 'Time must be in HH:MM format')
+
+export const CreateShiftSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Shift name is required')
+    .max(100, 'Shift name must be max 100 characters'),
+  start_time: TimeSchema,
+  end_time: TimeSchema,
+})
+
+export const UpdateShiftSchema = z.object({
+  id: z.string().uuid('Invalid shift ID'),
+  name: z.string().min(1).max(100).optional(),
+  start_time: TimeSchema.optional(),
+  end_time: TimeSchema.optional(),
+  is_active: z.boolean().optional(),
+})
+
+export type CreateShiftSchemaInput = z.infer<typeof CreateShiftSchema>
+export type UpdateShiftSchemaInput = z.infer<typeof UpdateShiftSchema>

--- a/src/features/shift-management/types/shift.types.ts
+++ b/src/features/shift-management/types/shift.types.ts
@@ -1,0 +1,38 @@
+// Shift Management Types (US-8.1, US-8.2)
+// Epic 8: Shift Management
+
+export interface Shift {
+  id: string
+  name: string
+  /** Wall-clock start time as stored string, e.g. "06:00:00" */
+  start_time: string
+  /** Wall-clock end time as stored string, e.g. "14:00:00" */
+  end_time: string
+  /**
+   * Whether this shift crosses midnight (start_time > end_time).
+   * Computed in the query layer; not a DB column.
+   */
+  crosses_midnight: boolean
+  is_default: boolean
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateShiftInput {
+  name: string
+  /** HH:MM format */
+  start_time: string
+  /** HH:MM format */
+  end_time: string
+}
+
+export interface UpdateShiftInput {
+  id: string
+  name?: string
+  /** HH:MM format */
+  start_time?: string
+  /** HH:MM format */
+  end_time?: string
+  is_active?: boolean
+}

--- a/src/features/stage-management/actions/stage-actions.ts
+++ b/src/features/stage-management/actions/stage-actions.ts
@@ -4,10 +4,14 @@ import { query, default as pool } from '@/shared/lib/db';
 import { revalidatePath } from 'next/cache';
 import type { Stage, CreateStageInput, UpdateStageInput } from '../types/stage.types';
 
-// Fetch all active stages ordered by display order
+// Fetch all active stages ordered by display order, including per-stage threshold (US-6.3)
 export async function getStages(): Promise<Stage[]> {
   const result = await query(
-    'SELECT * FROM stages WHERE is_active = TRUE ORDER BY display_order ASC'
+    `SELECT s.*, sdt.threshold_minutes
+     FROM stages s
+     LEFT JOIN stage_delay_thresholds sdt ON sdt.stage_id = s.id
+     WHERE s.is_active = TRUE
+     ORDER BY s.display_order ASC`
   );
   return result.rows as Stage[];
 }
@@ -43,7 +47,22 @@ export async function updateStage(input: UpdateStageInput) {
      WHERE id = $4`,
     [input.name?.trim(), input.color_code, input.description, input.id]
   );
+
+  // US-6.3: upsert or clear per-stage delay threshold
+  if (input.threshold_minutes && input.threshold_minutes > 0) {
+    await query(
+      `INSERT INTO stage_delay_thresholds (stage_id, threshold_minutes, updated_at)
+       VALUES ($1, $2, NOW())
+       ON CONFLICT (stage_id) DO UPDATE
+         SET threshold_minutes = EXCLUDED.threshold_minutes, updated_at = NOW()`,
+      [input.id, input.threshold_minutes]
+    );
+  } else if (input.threshold_minutes === null) {
+    await query('DELETE FROM stage_delay_thresholds WHERE stage_id = $1', [input.id]);
+  }
+
   revalidatePath('/admin/stages');
+  revalidatePath('/dashboard');
 }
 
 // Delete a stage (only non-default stages can be deleted)

--- a/src/features/stage-management/components/GlobalThresholdForm.tsx
+++ b/src/features/stage-management/components/GlobalThresholdForm.tsx
@@ -1,0 +1,93 @@
+'use client'
+// US-6.3: Global Delay Threshold configuration form (AC-1, AC-2, AC-4, AC-5)
+
+import { useState } from 'react'
+import { setGlobalThresholdAction } from '@/shared/actions/settings-actions'
+
+interface GlobalThresholdFormProps {
+  initialMinutes: number
+}
+
+export function GlobalThresholdForm({ initialMinutes }: GlobalThresholdFormProps) {
+  const [hours, setHours] = useState(Math.floor(initialMinutes / 60))
+  const [minutes, setMinutes] = useState(initialMinutes % 60)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [saved, setSaved] = useState(false)
+
+  const totalMinutes = hours * 60 + minutes
+  const preview =
+    hours > 0 && minutes > 0
+      ? `${hours}h ${minutes}min`
+      : hours > 0
+      ? `${hours} hour${hours !== 1 ? 's' : ''}`
+      : `${minutes} minutes`
+
+  const handleSave = async () => {
+    if (totalMinutes < 30) {
+      setError('Threshold must be at least 30 minutes')
+      return
+    }
+    setLoading(true)
+    setError('')
+    setSaved(false)
+    const res = await setGlobalThresholdAction({ hours, minutes })
+    setLoading(false)
+    if (res.success) {
+      setSaved(true)
+      setTimeout(() => setSaved(false), 3000)
+    } else {
+      setError(res.error ?? 'Failed to save')
+    }
+  }
+
+  return (
+    <div className='p-4 rounded-lg border-2 border-blue-200 bg-blue-50 mb-6'>
+      <h2 className='text-lg font-bold text-gray-900 mb-1'>Global Delay Threshold</h2>
+      <p className='text-sm text-gray-500 mb-4'>
+        Beds exceeding this time are flagged as delayed. Individual stages can override this.
+      </p>
+
+      <div className='flex items-end gap-4 flex-wrap'>
+        <div>
+          <label className='block text-xs font-semibold text-gray-700 mb-1'>Hours</label>
+          <input
+            type='number'
+            min={0}
+            max={24}
+            value={hours}
+            onChange={e => { setHours(Math.max(0, Math.min(24, Number(e.target.value)))); setSaved(false) }}
+            className='w-20 border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
+          />
+        </div>
+        <div>
+          <label className='block text-xs font-semibold text-gray-700 mb-1'>Minutes</label>
+          <input
+            type='number'
+            min={0}
+            max={59}
+            value={minutes}
+            onChange={e => { setMinutes(Math.max(0, Math.min(59, Number(e.target.value)))); setSaved(false) }}
+            className='w-20 border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
+          />
+        </div>
+        <div className='flex-1 min-w-[120px]'>
+          <p className='text-xs text-gray-500 mb-1'>Preview</p>
+          <p className={`font-semibold ${totalMinutes < 30 ? 'text-red-600' : 'text-blue-700'}`}>
+            {preview}
+          </p>
+        </div>
+        <button
+          onClick={handleSave}
+          disabled={loading || totalMinutes < 30}
+          className='px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 disabled:opacity-50'
+        >
+          {loading ? 'Saving…' : 'Save Threshold'}
+        </button>
+      </div>
+
+      {error && <p className='text-red-600 text-sm mt-2'>{error}</p>}
+      {saved && <p className='text-green-600 text-sm mt-2'>✓ Threshold updated — applies immediately</p>}
+    </div>
+  )
+}

--- a/src/features/stage-management/components/StageFormModal.tsx
+++ b/src/features/stage-management/components/StageFormModal.tsx
@@ -13,22 +13,37 @@ export function StageFormModal({ stage, onClose, onSaved }:
   const [name, setName] = useState(stage?.name ?? '');
   const [color, setColor] = useState(normalizeStageColor(stage?.color_code) ?? 'blue');
   const [desc, setDesc] = useState(stage?.description ?? '');
+  const stageThresholdMins = stage?.threshold_minutes ?? null;
+  const [thresholdHours, setThresholdHours] = useState(
+    stageThresholdMins ? Math.floor(stageThresholdMins / 60) : ''
+  );
+  const [thresholdMins, setThresholdMins] = useState(
+    stageThresholdMins ? stageThresholdMins % 60 : ''
+  );
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
   const handleSave = async () => {
     if (!name.trim()) return setError('Stage name is required');
     if (name.length > 50) return setError('Name must be max 50 characters');
+    const thH = Number(thresholdHours);
+    const thM = Number(thresholdMins);
+    const hasThreshold = thresholdHours !== '' || thresholdMins !== '';
+    const totalThresholdMins = hasThreshold ? thH * 60 + thM : null;
+    if (hasThreshold && (totalThresholdMins ?? 0) < 30)
+      return setError('Stage threshold must be at least 30 minutes');
     setLoading(true); setError('');
     try {
       if (stage) {
-        await updateStage({ id: stage.id, name, color_code: color, description: desc });
-        onSaved({ ...stage, name, color_code: color, description: desc });
+        await updateStage({ id: stage.id, name, color_code: color, description: desc,
+          threshold_minutes: totalThresholdMins });
+        onSaved({ ...stage, name, color_code: color, description: desc,
+          threshold_minutes: totalThresholdMins });
       } else {
         await createStage({ name, color_code: color, description: desc });
         onSaved({ id: Date.now().toString(), name, color_code: color,
           description: desc, display_order: 99, is_default: false,
-          is_active: true, created_at: '', updated_at: '' });
+          is_active: true, threshold_minutes: null, created_at: '', updated_at: '' });
       }
     } catch (e: unknown) { setError(e instanceof Error ? e.message : 'Something went wrong'); }
     finally { setLoading(false); }
@@ -86,6 +101,34 @@ export function StageFormModal({ stage, onClose, onSaved }:
           className='w-full border border-gray-300 rounded-lg px-3 py-2 mb-4 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
           placeholder='Stage description...'
         />
+
+        {/* Delay Threshold Override (US-6.3) */}
+        {stage && (
+          <>
+            <label className='block text-sm font-semibold text-gray-700 mb-1'>
+              Delay Threshold Override
+              <span className='text-gray-400 font-normal ml-1'>(Optional — leave blank to use global)</span>
+            </label>
+            <div className='flex gap-2 mb-4'>
+              <input
+                type='number' min={0} max={24} placeholder='hrs'
+                value={thresholdHours}
+                onChange={e => setThresholdHours(e.target.value === '' ? '' : Math.max(0, Math.min(24, Number(e.target.value))))}
+                className='w-20 border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
+              />
+              <input
+                type='number' min={0} max={59} placeholder='min'
+                value={thresholdMins}
+                onChange={e => setThresholdMins(e.target.value === '' ? '' : Math.max(0, Math.min(59, Number(e.target.value))))}
+                className='w-20 border border-gray-300 rounded-lg px-3 py-2 text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500'
+              />
+              {(thresholdHours !== '' || thresholdMins !== '') && (
+                <button type='button' onClick={() => { setThresholdHours(''); setThresholdMins(''); }}
+                  className='text-xs text-red-500 hover:underline px-2'>Clear</button>
+              )}
+            </div>
+          </>
+        )}
 
         {/* Error */}
         {error && <p className='text-red-600 text-sm mb-3'>{error}</p>}

--- a/src/features/stage-management/components/StageList.tsx
+++ b/src/features/stage-management/components/StageList.tsx
@@ -49,6 +49,13 @@ export function StageList({ initialStages }: { initialStages: Stage[] }) {
                   Default
                 </span>
               )}
+              {stage.threshold_minutes && (
+                <span className='text-xs bg-amber-900/40 px-2 py-0.5 rounded-full text-amber-200 border border-amber-700'>
+                  ⏱ {stage.threshold_minutes >= 60
+                    ? `${Math.floor(stage.threshold_minutes / 60)}h ${stage.threshold_minutes % 60 > 0 ? `${stage.threshold_minutes % 60}m` : ''}`
+                    : `${stage.threshold_minutes}m`}
+                </span>
+              )}
             </div>
 
           <div className='flex gap-2'>

--- a/src/features/stage-management/types/stage.types.ts
+++ b/src/features/stage-management/types/stage.types.ts
@@ -6,6 +6,7 @@ export interface Stage {
   description?: string;
   is_default: boolean;
   is_active: boolean;
+  threshold_minutes?: number | null; // US-6.3: per-stage override (null = use global)
   created_at: string;
   updated_at: string;
 }
@@ -21,4 +22,5 @@ export interface UpdateStageInput {
   name?: string;
   color_code?: string;
   description?: string;
+  threshold_minutes?: number | null; // US-6.3
 }

--- a/src/shared/actions/settings-actions.ts
+++ b/src/shared/actions/settings-actions.ts
@@ -1,0 +1,131 @@
+'use server'
+// US-6.3: System Settings Server Actions — admin-only global threshold management
+
+import { query } from '@/shared/lib/db'
+import { revalidatePath } from 'next/cache'
+import { requireRole } from '@/shared/lib/auth'
+import { logAudit } from '@/shared/lib/audit'
+import { logger } from '@/shared/config/logger'
+import { z } from 'zod'
+import { getGlobalThresholdMinutes } from '@/shared/lib/threshold'
+
+const SetThresholdSchema = z.object({
+  hours: z.coerce.number().int().min(0).max(24),
+  minutes: z.coerce.number().int().min(0).max(59),
+}).refine(({ hours, minutes }) => hours * 60 + minutes >= 30, {
+  message: 'Threshold must be at least 30 minutes',
+})
+
+export async function getGlobalThresholdAction(): Promise<{
+  success: boolean
+  minutes?: number
+  error?: string
+}> {
+  try {
+    const minutes = await getGlobalThresholdMinutes()
+    return { success: true, minutes }
+  } catch (err) {
+    logger.error('getGlobalThresholdAction failed', err as Error)
+    return { success: false, error: 'Failed to load threshold' }
+  }
+}
+
+export async function setGlobalThresholdAction(input: {
+  hours: number
+  minutes: number
+}): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await requireRole(['admin'])
+    const parsed = SetThresholdSchema.safeParse(input)
+    if (!parsed.success) {
+      const firstError = Object.values(parsed.error.flatten().fieldErrors)[0]?.[0]
+      return { success: false, error: firstError ?? 'Validation error' }
+    }
+    const totalMinutes = parsed.data.hours * 60 + parsed.data.minutes
+    await query(
+      `INSERT INTO system_settings (key, value, updated_at)
+       VALUES ('delay_threshold_minutes', $1, NOW())
+       ON CONFLICT (key) DO UPDATE
+         SET value = EXCLUDED.value, updated_at = NOW()`,
+      [String(totalMinutes)]
+    )
+    await logAudit({
+      actionType: 'UPDATE',
+      entityType: 'system_setting',
+      entityId: 'delay_threshold_minutes',
+      performedBy: session.userId,
+      changes: { delay_threshold_minutes: totalMinutes },
+    })
+    logger.info('Global threshold updated', { totalMinutes, performedBy: session.userId })
+    revalidatePath('/admin/stages')
+    revalidatePath('/dashboard')
+    return { success: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update threshold'
+    logger.error('setGlobalThresholdAction failed', err as Error)
+    return { success: false, error: message }
+  }
+}
+
+export async function setStageThresholdAction(input: {
+  stageId: string
+  hours: number
+  minutes: number
+}): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await requireRole(['admin'])
+    const parsed = SetThresholdSchema.safeParse({ hours: input.hours, minutes: input.minutes })
+    if (!parsed.success) {
+      const firstError = Object.values(parsed.error.flatten().fieldErrors)[0]?.[0]
+      return { success: false, error: firstError ?? 'Validation error' }
+    }
+    const totalMinutes = parsed.data.hours * 60 + parsed.data.minutes
+    await query(
+      `INSERT INTO stage_delay_thresholds (stage_id, threshold_minutes, updated_at)
+       VALUES ($1, $2, NOW())
+       ON CONFLICT (stage_id) DO UPDATE
+         SET threshold_minutes = EXCLUDED.threshold_minutes, updated_at = NOW()`,
+      [input.stageId, totalMinutes]
+    )
+    await logAudit({
+      actionType: 'UPDATE',
+      entityType: 'stage_threshold',
+      entityId: input.stageId,
+      performedBy: session.userId,
+      changes: { threshold_minutes: totalMinutes },
+    })
+    logger.info('Stage threshold updated', { stageId: input.stageId, totalMinutes })
+    revalidatePath('/admin/stages')
+    revalidatePath('/dashboard')
+    return { success: true }
+  } catch (err) {
+    logger.error('setStageThresholdAction failed', err as Error)
+    return { success: false, error: 'Failed to update stage threshold' }
+  }
+}
+
+export async function clearStageThresholdAction(
+  stageId: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await requireRole(['admin'])
+    await query(
+      `DELETE FROM stage_delay_thresholds WHERE stage_id = $1`,
+      [stageId]
+    )
+    await logAudit({
+      actionType: 'DELETE',
+      entityType: 'stage_threshold',
+      entityId: stageId,
+      performedBy: session.userId,
+      changes: {},
+    })
+    logger.info('Stage threshold cleared', { stageId, performedBy: session.userId })
+    revalidatePath('/admin/stages')
+    revalidatePath('/dashboard')
+    return { success: true }
+  } catch (err) {
+    logger.error('clearStageThresholdAction failed', err as Error)
+    return { success: false, error: 'Failed to clear stage threshold' }
+  }
+}

--- a/src/shared/lib/threshold.ts
+++ b/src/shared/lib/threshold.ts
@@ -1,0 +1,56 @@
+import 'server-only'
+// US-6.3: Threshold resolution — single source of truth for delay thresholds
+// Reads from system_settings (global) and stage_delay_thresholds (per-stage override)
+
+import { query } from '@/shared/lib/db'
+import { logger } from '@/shared/config/logger'
+
+const DEFAULT_THRESHOLD_MINUTES = 180 // 3 hours fallback if DB unavailable
+
+/**
+ * Returns the global delay threshold in minutes from system_settings.
+ * Falls back to 180 minutes (3 hours) if not configured.
+ */
+export async function getGlobalThresholdMinutes(): Promise<number> {
+  try {
+    const result = await query<{ value: string }>(
+      `SELECT value FROM system_settings WHERE key = 'delay_threshold_minutes'`,
+      []
+    )
+    if (result.rows.length > 0) {
+      return parseInt(result.rows[0].value, 10)
+    }
+  } catch (err) {
+    logger.error('getGlobalThresholdMinutes failed, using default', err as Error)
+  }
+  return DEFAULT_THRESHOLD_MINUTES
+}
+
+/**
+ * Returns the global delay threshold in milliseconds.
+ */
+export async function getGlobalThresholdMs(): Promise<number> {
+  const minutes = await getGlobalThresholdMinutes()
+  return minutes * 60 * 1000
+}
+
+/**
+ * Returns the effective threshold in minutes for a given stage.
+ * Checks stage_delay_thresholds first, falls back to global.
+ */
+export async function getEffectiveThresholdMinutes(stageId?: string): Promise<number> {
+  if (stageId) {
+    try {
+      const result = await query<{ threshold_minutes: number }>(
+        `SELECT threshold_minutes FROM stage_delay_thresholds WHERE stage_id = $1`,
+        [stageId]
+      )
+      if (result.rows.length > 0) {
+        return result.rows[0].threshold_minutes
+      }
+    } catch (err) {
+      logger.error('getEffectiveThresholdMinutes stage lookup failed', err as Error)
+    }
+  }
+  return getGlobalThresholdMinutes()
+}


### PR DESCRIPTION
## Shift Management — EPIC 8 (US-8.1 + US-8.2 + US-6.3)

Closes #50
Closes #51
Closes #43

### What changed

**US-8.1 — Define Shift Schedules (#50)**
- New `shifts` table (migration 015) with 3 seeded defaults: Morning 06:00–14:00, Evening 14:00–22:00, Night 22:00–06:00
- Admin UI at `/admin/shifts` to create, edit, and soft-delete custom shifts
- Midnight-crossing shifts supported (e.g. Night: 22:00–06:00)

**US-8.2 — Tag Data by Shift (#51)**
- Migration 016 adds `shift_id` + `shift_override_by_user_id` to `bed_stage_logs`, and `shift_id` to `patient_admissions`
- Every bed stage update auto-tags the active shift at transaction time (inline SQL subquery — no race condition)
- Supervisors/admins can manually override the shift on any log entry

**US-6.3 — Set Time Thresholds (#43)**
- Migrations 017 (`system_settings`) + 018 (`stage_delay_thresholds`)
- Global threshold configurable in admin → Stages (default 3 hours)
- Per-stage overrides supported — shown as badge in stage list
- Delay flags in bed dashboard now read from DB instead of env var
- Threshold changes apply immediately (no restart needed)


### Migrations
`015_create_shifts.sql` · `016_add_shift_id_to_logs.sql` · `017_create_system_settings.sql` · `018_create_stage_delay_thresholds.sql`

### Tests
283/283 passing · 0 lint errors · build clean