### PR TITLE
Feature/issue 88 89 archive retention

### DIFF
--- a/migrations/022_create_archival_tables.sql
+++ b/migrations/022_create_archival_tables.sql
@@ -1,0 +1,96 @@
+-- Migration 022: Data Retention & Archival tables
+-- EPIC 14 — US-14.1: Automated Data Archival
+--
+-- Creates mirror archive tables for patient_admissions and audit_logs,
+-- plus an archival_runs log that tracks every archival job execution.
+--
+-- Archive tables intentionally have no FK constraints — the live rows
+-- they reference may have been deleted by the time someone queries the archive.
+
+-- ── patient_admissions_archive ────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS patient_admissions_archive (
+    id                              UUID        NOT NULL,
+    bed_id                          UUID        NOT NULL,
+    admitted_at                     TIMESTAMPTZ NOT NULL,
+    discharged_at                   TIMESTAMPTZ NOT NULL,
+    total_duration_ms               BIGINT      NOT NULL,
+    discharged_by_user_id           UUID        NOT NULL,
+    notes                           TEXT,
+    created_at                      TIMESTAMPTZ NOT NULL,
+    tat_from_previous_discharge_ms  BIGINT,
+    -- Archival metadata
+    archived_at                     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pa_archive_discharged_at
+    ON patient_admissions_archive(discharged_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pa_archive_bed_id
+    ON patient_admissions_archive(bed_id);
+
+COMMENT ON TABLE patient_admissions_archive IS
+    'Cold store for patient_admissions rows past the configured retention period.';
+
+-- ── audit_logs_archive ────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS audit_logs_archive (
+    id                      UUID        NOT NULL,
+    action_type             VARCHAR(50) NOT NULL,
+    entity_type             VARCHAR(50) NOT NULL,
+    entity_id               UUID        NOT NULL,
+    performed_by_user_id    UUID        NOT NULL,
+    target_user_id          UUID,
+    changes                 JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    reason                  TEXT,
+    metadata                JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    ip_address              INET,
+    created_at              TIMESTAMPTZ NOT NULL,
+    -- Archival metadata
+    archived_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_al_archive_created_at
+    ON audit_logs_archive(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_al_archive_entity
+    ON audit_logs_archive(entity_type, entity_id);
+
+COMMENT ON TABLE audit_logs_archive IS
+    'Cold store for audit_logs rows past the configured retention period.';
+
+-- ── archival_runs ─────────────────────────────────────────────────────────
+
+CREATE TYPE archival_run_status AS ENUM (
+    'running',
+    'pending_approval',
+    'completed',
+    'failed'
+);
+
+CREATE TABLE IF NOT EXISTS archival_runs (
+    id                  UUID            PRIMARY KEY DEFAULT uuid_generate_v4(),
+    triggered_by        TEXT            NOT NULL,  -- 'cron' or user_id
+    status              archival_run_status NOT NULL DEFAULT 'running',
+    cutoff_date         TIMESTAMPTZ     NOT NULL,
+    started_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    ended_at            TIMESTAMPTZ,
+    rows_archived       JSONB           NOT NULL DEFAULT '{}'::jsonb,
+    error_message       TEXT,
+    CONSTRAINT chk_ended_after_started CHECK (ended_at IS NULL OR ended_at >= started_at)
+);
+
+COMMENT ON TABLE archival_runs IS
+    'Audit trail of every archival job: one row per execution.';
+
+COMMENT ON COLUMN archival_runs.triggered_by IS
+    '''cron'' for scheduled runs, or the user_id UUID for manual admin triggers.';
+
+COMMENT ON COLUMN archival_runs.rows_archived IS
+    'JSON map of table → row count, e.g. {"patient_admissions":120,"audit_logs":450}';
+
+-- Down Migration
+-- DROP TABLE IF EXISTS patient_admissions_archive;
+-- DROP TABLE IF EXISTS audit_logs_archive;
+-- DROP TABLE IF EXISTS archival_runs;
+-- DROP TYPE IF EXISTS archival_run_status;

--- a/migrations/023_seed_retention_settings.sql
+++ b/migrations/023_seed_retention_settings.sql
@@ -1,0 +1,32 @@
+-- Migration 023: Seed default retention configuration into system_settings
+-- EPIC 14 — US-14.2: Configurable Data Retention
+--
+-- Inserts default retention periods (years) and behaviour flags.
+-- All values match legal minimums for Indian medical records (7 years).
+-- ON CONFLICT DO NOTHING — safe to re-run; manual admin changes are preserved.
+
+INSERT INTO system_settings (key, value, description) VALUES
+(
+    'retention_patient_admissions_years',
+    '7',
+    'Years to retain patient_admissions rows before archiving (EPIC 14)'
+),
+(
+    'retention_audit_logs_years',
+    '7',
+    'Years to retain audit_logs rows before archiving (EPIC 14)'
+),
+(
+    'retention_bed_stage_log_years',
+    '2',
+    'Years to retain bed_stage_log rows before archiving (EPIC 14)'
+),
+(
+    'retention_requires_approval',
+    'true',
+    'When true, cron-triggered archival jobs pause for admin approval before deleting data (EPIC 14)'
+)
+ON CONFLICT (key) DO NOTHING;
+
+-- Down Migration
+-- DELETE FROM system_settings WHERE key LIKE 'retention_%';

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -5,7 +5,10 @@ import { LosView } from '@/features/bed-dashboard/components/LosView'
 import { PatientCountView } from '@/features/management-report/components/PatientCountView'
 import { ShiftReportView } from '@/features/shift-management/components/ShiftReportView'
 import { ShiftComparisonView } from '@/features/shift-management/components/ShiftComparisonView'
+import { DataRetentionView } from '@/features/data-retention/components/DataRetentionView'
 import { getShifts } from '@/features/shift-management/lib/shift-queries'
+import { getRetentionConfig } from '@/features/data-retention/lib/retention-config-queries'
+import { getRecentArchivalRuns } from '@/features/data-retention/lib/archival-queries'
 import { verifyActiveSession } from '@/shared/lib/active-session'
 import { redirect } from 'next/navigation'
 import { Button } from '@/shared/components/ui/button'
@@ -59,6 +62,11 @@ export default async function AnalyticsPage() {
   } catch {
     // Non-blocking: components will render with an empty shift list gracefully
   }
+
+  // EPIC 14: Retention config + recent archival runs — admin and auditor only
+  const isRetentionVisible = session.role === 'admin' || session.role === 'auditor'
+  const retentionConfig = isRetentionVisible ? await getRetentionConfig().catch(() => null) : null
+  const archivalRuns   = isRetentionVisible ? await getRecentArchivalRuns(10).catch(() => []) : []
 
   return (
     <div className="min-h-screen bg-black text-foreground p-8">
@@ -115,6 +123,15 @@ export default async function AnalyticsPage() {
 
         {/* Shift Performance Comparison (US-8.4) */}
         <ShiftComparisonView readOnly={isAuditMode} />
+
+        {/* ── Data Retention & Archival (EPIC 14 / US-14.1, US-14.2) ───── */}
+        {isRetentionVisible && retentionConfig && (
+          <DataRetentionView
+            initialConfig={retentionConfig}
+            initialRuns={archivalRuns}
+            readOnly={isAuditMode}
+          />
+        )}
       </div>
     </div>
   )

--- a/src/app/api/cron/archival/route.ts
+++ b/src/app/api/cron/archival/route.ts
@@ -1,0 +1,98 @@
+// /api/cron/archival — scheduled archival endpoint
+// EPIC 14 — US-14.1: Archival runs automatically monthly
+//
+// Called by: Vercel Cron / system cron at  0 0 1 * *  (midnight on the 1st)
+// Protected by: CRON_SECRET header — must match process.env.CRON_SECRET
+//
+// When retention_requires_approval = true:  creates a pending_approval run,
+//   no data is moved until an admin approves it in the UI.
+// When retention_requires_approval = false: archives immediately.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { logger } from '@/shared/config/logger'
+import { query } from '@/shared/lib/db'
+import { archiveTables } from '@/features/data-retention/lib/archival-runner'
+import { getRetentionConfig } from '@/features/data-retention/lib/retention-config-queries'
+
+function cutoffFromYears(years: number): Date {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() - years)
+  return d
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  // ── Auth ──────────────────────────────────────────────────────────────
+  const cronSecret = process.env.CRON_SECRET
+  if (!cronSecret) {
+    logger.error('CRON_SECRET env var not set — archival cron disabled')
+    return NextResponse.json({ error: 'Not configured' }, { status: 500 })
+  }
+
+  const authHeader = request.headers.get('authorization')
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // ── Config ────────────────────────────────────────────────────────────
+  const config = await getRetentionConfig()
+  const cutoffDate = cutoffFromYears(
+    Math.min(
+      config.patientAdmissionsYears,
+      config.auditLogsYears,
+      config.bedStageLogYears,
+    ),
+  )
+
+  // ── Approval gate ─────────────────────────────────────────────────────
+  if (config.requiresApproval) {
+    const result = await query<{ id: string }>(
+      `INSERT INTO archival_runs (triggered_by, status, cutoff_date)
+       VALUES ('cron', 'pending_approval', $1)
+       RETURNING id`,
+      [cutoffDate],
+    )
+    const runId = result.rows[0].id
+    logger.info('Archival cron created pending_approval run', { runId, cutoffDate })
+    return NextResponse.json({ status: 'pending_approval', runId })
+  }
+
+  // ── Immediate run ─────────────────────────────────────────────────────
+  const runResult = await query<{ id: string }>(
+    `INSERT INTO archival_runs (triggered_by, status, cutoff_date)
+     VALUES ('cron', 'running', $1)
+     RETURNING id`,
+    [cutoffDate],
+  )
+  const runId = runResult.rows[0].id
+
+  const tableResults = await archiveTables(cutoffDate)
+  const rowsArchived: Record<string, number> = {}
+  const errors: string[] = []
+
+  for (const r of tableResults) {
+    rowsArchived[r.table] = r.rowsMoved
+    if (r.error) errors.push(`${r.table}: ${r.error}`)
+  }
+
+  if (errors.length > 0) {
+    const errorMessage = errors.join('; ')
+    await query(
+      `UPDATE archival_runs
+       SET status = 'failed', ended_at = NOW(), error_message = $2
+       WHERE id = $1`,
+      [runId, errorMessage],
+    )
+    logger.error('Cron archival run failed', new Error(errorMessage), { runId })
+    return NextResponse.json({ status: 'failed', runId, error: errorMessage }, { status: 500 })
+  }
+
+  await query(
+    `UPDATE archival_runs
+     SET status = 'completed', ended_at = NOW(), rows_archived = $2
+     WHERE id = $1`,
+    [runId, JSON.stringify(rowsArchived)],
+  )
+
+  logger.info('Cron archival run completed', { runId, rowsArchived })
+  return NextResponse.json({ status: 'completed', runId, rowsArchived })
+}

--- a/src/app/api/cron/archival/route.ts
+++ b/src/app/api/cron/archival/route.ts
@@ -13,12 +13,7 @@ import { logger } from '@/shared/config/logger'
 import { query } from '@/shared/lib/db'
 import { archiveTables } from '@/features/data-retention/lib/archival-runner'
 import { getRetentionConfig } from '@/features/data-retention/lib/retention-config-queries'
-
-function cutoffFromYears(years: number): Date {
-  const d = new Date()
-  d.setFullYear(d.getFullYear() - years)
-  return d
-}
+import { buildCutoffs } from '@/features/data-retention/lib/archival-run-helpers'
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   // ── Auth ──────────────────────────────────────────────────────────────
@@ -35,12 +30,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
   // ── Config ────────────────────────────────────────────────────────────
   const config = await getRetentionConfig()
-  const cutoffDate = cutoffFromYears(
-    Math.min(
-      config.patientAdmissionsYears,
-      config.auditLogsYears,
-      config.bedStageLogYears,
-    ),
+  const cutoffs = buildCutoffs(config)
+  // Earliest cutoff stored in the run record (for display only)
+  const earliestCutoff = new Date(
+    Math.min(cutoffs.patientAdmissions.getTime(), cutoffs.auditLogs.getTime()),
   )
 
   // ── Approval gate ─────────────────────────────────────────────────────
@@ -49,10 +42,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       `INSERT INTO archival_runs (triggered_by, status, cutoff_date)
        VALUES ('cron', 'pending_approval', $1)
        RETURNING id`,
-      [cutoffDate],
+      [earliestCutoff],
     )
     const runId = result.rows[0].id
-    logger.info('Archival cron created pending_approval run', { runId, cutoffDate })
+    logger.info('Archival cron created pending_approval run', { runId, cutoffs })
     return NextResponse.json({ status: 'pending_approval', runId })
   }
 
@@ -61,11 +54,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     `INSERT INTO archival_runs (triggered_by, status, cutoff_date)
      VALUES ('cron', 'running', $1)
      RETURNING id`,
-    [cutoffDate],
+    [earliestCutoff],
   )
   const runId = runResult.rows[0].id
 
-  const tableResults = await archiveTables(cutoffDate)
+  const tableResults = await archiveTables(cutoffs)
   const rowsArchived: Record<string, number> = {}
   const errors: string[] = []
 

--- a/src/features/data-retention/actions/archival-actions.ts
+++ b/src/features/data-retention/actions/archival-actions.ts
@@ -1,0 +1,147 @@
+'use server'
+// archival-actions.ts — server actions for US-14.1
+// EPIC 14: Data Retention & Archival
+//
+// triggerArchival: admin-only manual run.
+// approveArchival: admin-only approval of a pending_approval cron run.
+// fetchArchivalRuns: read access for admin + auditor.
+
+import { requireRole } from '@/shared/lib/auth'
+import { logger } from '@/shared/config/logger'
+import { logAudit } from '@/shared/lib/audit'
+import { query } from '@/shared/lib/db'
+import { archiveTables } from '../lib/archival-runner'
+import { getRetentionConfig } from '../lib/retention-config-queries'
+import { getRecentArchivalRuns, getArchivalRunById } from '../lib/archival-queries'
+import {
+  createRunRecord,
+  finaliseRunRecord,
+  failRunRecord,
+  collectResults,
+  computeCutoffDate,
+} from '../lib/archival-run-helpers'
+import type { ArchivalRun } from '../lib/data-retention-types'
+
+export interface TriggerArchivalResult {
+  success: boolean
+  runId?: string
+  rowsArchived?: Record<string, number>
+  error?: string
+}
+
+export interface FetchArchivalRunsResult {
+  success: boolean
+  data?: ArchivalRun[]
+  error?: string
+}
+
+// ── Actions ────────────────────────────────────────────────────────────────
+
+/**
+ * Manually trigger an archival run. Admin only.
+ * Manual triggers bypass the approval gate — the click is the approval.
+ */
+export async function triggerArchival(): Promise<TriggerArchivalResult> {
+  try {
+    const session = await requireRole('admin')
+
+    const config = await getRetentionConfig()
+    const cutoffDate = computeCutoffDate([
+      config.patientAdmissionsYears,
+      config.auditLogsYears,
+      config.bedStageLogYears,
+    ])
+
+    const runId = await createRunRecord(session.userId, cutoffDate)
+
+    logger.info('Manual archival run started', { runId, cutoffDate, adminId: session.userId })
+
+    const tableResults = await archiveTables(cutoffDate)
+    const { rowsArchived, errors } = collectResults(tableResults)
+
+    if (errors.length > 0) {
+      const errorMessage = errors.join('; ')
+      await failRunRecord(runId, errorMessage)
+      return { success: false, runId, rowsArchived, error: errorMessage }
+    }
+
+    await finaliseRunRecord(runId, rowsArchived)
+
+    await logAudit({
+      actionType: 'ARCHIVE',
+      entityType: 'archival_run',
+      entityId: runId,
+      performedBy: session.userId,
+      changes: { rowsArchived, cutoffDate },
+    })
+
+    logger.info('Manual archival run completed', { runId, rowsArchived })
+
+    return { success: true, runId, rowsArchived }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Archival failed'
+    logger.error('triggerArchival failed', error as Error)
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * Approve a pending_approval archival run and execute it. Admin only.
+ * Used when requiresApproval = true and the cron created a pending run.
+ */
+export async function approveArchival(runId: string): Promise<TriggerArchivalResult> {
+  try {
+    const session = await requireRole('admin')
+
+    const run = await getArchivalRunById(runId)
+    if (!run) return { success: false, error: 'Archival run not found' }
+    if (run.status !== 'pending_approval') {
+      return { success: false, error: `Run is not pending approval (status: ${run.status})` }
+    }
+
+    await query(
+      `UPDATE archival_runs SET status = 'running', triggered_by = $2 WHERE id = $1`,
+      [runId, session.userId],
+    )
+
+    const tableResults = await archiveTables(run.cutoffDate)
+    const { rowsArchived, errors } = collectResults(tableResults)
+
+    if (errors.length > 0) {
+      const errorMessage = errors.join('; ')
+      await failRunRecord(runId, errorMessage)
+      return { success: false, runId, rowsArchived, error: errorMessage }
+    }
+
+    await finaliseRunRecord(runId, rowsArchived)
+
+    await logAudit({
+      actionType: 'ARCHIVE_APPROVE',
+      entityType: 'archival_run',
+      entityId: runId,
+      performedBy: session.userId,
+      changes: { rowsArchived, cutoffDate: run.cutoffDate },
+    })
+
+    logger.info('Archival run approved and completed', { runId, rowsArchived })
+
+    return { success: true, runId, rowsArchived }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Archival approval failed'
+    logger.error('approveArchival failed', error as Error)
+    return { success: false, error: message }
+  }
+}
+
+/** Fetch the most recent archival run records. Accessible by admin + auditor. */
+export async function fetchArchivalRuns(): Promise<FetchArchivalRunsResult> {
+  try {
+    await requireRole(['admin', 'auditor'])
+    const data = await getRecentArchivalRuns(10)
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch archival runs'
+    logger.error('fetchArchivalRuns failed', error as Error)
+    return { success: false, error: message }
+  }
+}

--- a/src/features/data-retention/actions/archival-actions.ts
+++ b/src/features/data-retention/actions/archival-actions.ts
@@ -18,7 +18,7 @@ import {
   finaliseRunRecord,
   failRunRecord,
   collectResults,
-  computeCutoffDate,
+  buildCutoffs,
 } from '../lib/archival-run-helpers'
 import type { ArchivalRun } from '../lib/data-retention-types'
 
@@ -46,17 +46,13 @@ export async function triggerArchival(): Promise<TriggerArchivalResult> {
     const session = await requireRole('admin')
 
     const config = await getRetentionConfig()
-    const cutoffDate = computeCutoffDate([
-      config.patientAdmissionsYears,
-      config.auditLogsYears,
-      config.bedStageLogYears,
-    ])
+    const cutoffs = buildCutoffs(config)
 
-    const runId = await createRunRecord(session.userId, cutoffDate)
+    const runId = await createRunRecord(session.userId, cutoffs)
 
-    logger.info('Manual archival run started', { runId, cutoffDate, adminId: session.userId })
+    logger.info('Manual archival run started', { runId, cutoffs, adminId: session.userId })
 
-    const tableResults = await archiveTables(cutoffDate)
+    const tableResults = await archiveTables(cutoffs)
     const { rowsArchived, errors } = collectResults(tableResults)
 
     if (errors.length > 0) {
@@ -72,7 +68,7 @@ export async function triggerArchival(): Promise<TriggerArchivalResult> {
       entityType: 'archival_run',
       entityId: runId,
       performedBy: session.userId,
-      changes: { rowsArchived, cutoffDate },
+      changes: { rowsArchived, cutoffs },
     })
 
     logger.info('Manual archival run completed', { runId, rowsArchived })
@@ -104,7 +100,14 @@ export async function approveArchival(runId: string): Promise<TriggerArchivalRes
       [runId, session.userId],
     )
 
-    const tableResults = await archiveTables(run.cutoffDate)
+    // Re-read current config to get per-table cutoffs.
+    // The stored cutoff_date in the run record is the earliest of those cutoffs — used
+    // only for display. We derive per-table dates from the live config so each table
+    // respects its own retention period.
+    const config = await getRetentionConfig()
+    const cutoffs = buildCutoffs(config)
+
+    const tableResults = await archiveTables(cutoffs)
     const { rowsArchived, errors } = collectResults(tableResults)
 
     if (errors.length > 0) {
@@ -120,7 +123,7 @@ export async function approveArchival(runId: string): Promise<TriggerArchivalRes
       entityType: 'archival_run',
       entityId: runId,
       performedBy: session.userId,
-      changes: { rowsArchived, cutoffDate: run.cutoffDate },
+      changes: { rowsArchived, cutoffs, storedCutoffDate: run.cutoffDate },
     })
 
     logger.info('Archival run approved and completed', { runId, rowsArchived })

--- a/src/features/data-retention/actions/retention-config-actions.ts
+++ b/src/features/data-retention/actions/retention-config-actions.ts
@@ -1,0 +1,82 @@
+'use server'
+// retention-config-actions.ts — server actions for US-14.2
+// EPIC 14: Data Retention & Archival
+//
+// Admin-only write. Read access: admin + auditor (compliance officer).
+
+import { requireRole } from '@/shared/lib/auth'
+import { logger } from '@/shared/config/logger'
+import { logAudit } from '@/shared/lib/audit'
+import { getRetentionConfig, saveRetentionConfig } from '../lib/retention-config-queries'
+import type { RetentionConfig } from '../lib/data-retention-types'
+
+export interface FetchRetentionConfigResult {
+  success: boolean
+  data?: RetentionConfig
+  error?: string
+}
+
+export interface SaveRetentionConfigResult {
+  success: boolean
+  error?: string
+}
+
+/** Fetch the current retention configuration. Accessible by admin and auditor. */
+export async function fetchRetentionConfig(): Promise<FetchRetentionConfigResult> {
+  try {
+    await requireRole(['admin', 'auditor'])
+
+    const data = await getRetentionConfig()
+    return { success: true, data }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch retention config'
+    logger.error('fetchRetentionConfig failed', error as Error)
+    return { success: false, error: message }
+  }
+}
+
+/**
+ * Persist updated retention configuration. Admin only.
+ * Validates that all period values are positive integers ≤ 99 years.
+ */
+export async function updateRetentionConfig(
+  config: RetentionConfig,
+): Promise<SaveRetentionConfigResult> {
+  try {
+    const session = await requireRole('admin')
+
+    const yearFields: Array<keyof RetentionConfig> = [
+      'patientAdmissionsYears',
+      'auditLogsYears',
+      'bedStageLogYears',
+    ]
+
+    for (const field of yearFields) {
+      const val = config[field] as number
+      if (!Number.isInteger(val) || val < 1 || val > 99) {
+        return {
+          success: false,
+          error: `${field} must be a whole number between 1 and 99`,
+        }
+      }
+    }
+
+    await saveRetentionConfig(config)
+
+    await logAudit({
+      actionType: 'UPDATE',
+      entityType: 'retention_config',
+      entityId: 'system',
+      performedBy: session.userId,
+      changes: { ...config },
+    })
+
+    logger.info('Retention config updated', { adminId: session.userId, ...config })
+
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to save retention config'
+    logger.error('updateRetentionConfig failed', error as Error)
+    return { success: false, error: message }
+  }
+}

--- a/src/features/data-retention/components/ArchivalRunsTable.tsx
+++ b/src/features/data-retention/components/ArchivalRunsTable.tsx
@@ -1,0 +1,121 @@
+// ArchivalRunsTable — shows recent archival run history with approve button
+// EPIC 14 — US-14.1
+
+'use client'
+
+import { useTransition } from 'react'
+import { CheckCircle, XCircle, Clock, Loader2, ShieldCheck } from 'lucide-react'
+import { Button } from '@/shared/components/ui/button'
+import { cn } from '@/shared/lib/utils'
+import { approveArchival } from '../actions/archival-actions'
+import type { ArchivalRun, ArchivalRunStatus } from '../lib/data-retention-types'
+
+interface ArchivalRunsTableProps {
+  runs: ArchivalRun[]
+  onApproved?: () => void
+}
+
+const STATUS_ICON: Record<ArchivalRunStatus, React.ReactNode> = {
+  completed:        <CheckCircle className="h-4 w-4 text-green-400" />,
+  failed:           <XCircle className="h-4 w-4 text-red-400" />,
+  running:          <Loader2 className="h-4 w-4 text-blue-400 animate-spin" />,
+  pending_approval: <Clock className="h-4 w-4 text-yellow-400" />,
+}
+
+const STATUS_LABEL: Record<ArchivalRunStatus, string> = {
+  completed:        'Completed',
+  failed:           'Failed',
+  running:          'Running',
+  pending_approval: 'Awaiting Approval',
+}
+
+function formatDate(d: Date | null): string {
+  if (!d) return '—'
+  return new Date(d).toLocaleString('en-GB', {
+    day: '2-digit', month: 'short', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+}
+
+function totalRowsArchived(rowsArchived: Record<string, number>): number {
+  return Object.values(rowsArchived).reduce((sum, n) => sum + n, 0)
+}
+
+export function ArchivalRunsTable({ runs, onApproved }: ArchivalRunsTableProps) {
+  const [isPending, startTransition] = useTransition()
+
+  function handleApprove(runId: string) {
+    startTransition(async () => {
+      await approveArchival(runId)
+      onApproved?.()
+    })
+  }
+
+  if (runs.length === 0) {
+    return (
+      <p className="text-sm text-zinc-500 py-4 text-center">
+        No archival runs yet.
+      </p>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-zinc-500 border-b border-zinc-800">
+            <th className="pb-2 text-left font-medium">Started</th>
+            <th className="pb-2 text-left font-medium">Cutoff date</th>
+            <th className="pb-2 text-left font-medium">Status</th>
+            <th className="pb-2 text-right font-medium">Rows archived</th>
+            <th className="pb-2 text-left font-medium">Triggered by</th>
+            <th className="pb-2" />
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-800/60">
+          {runs.map((run) => (
+            <tr key={run.id} className="text-zinc-300">
+              <td className="py-2 pr-4 whitespace-nowrap">{formatDate(run.startedAt)}</td>
+              <td className="py-2 pr-4 whitespace-nowrap">{formatDate(run.cutoffDate)}</td>
+              <td className="py-2 pr-4">
+                <span className="flex items-center gap-1.5">
+                  {STATUS_ICON[run.status]}
+                  <span className={cn(
+                    run.status === 'failed' && 'text-red-400',
+                    run.status === 'pending_approval' && 'text-yellow-400',
+                  )}>
+                    {STATUS_LABEL[run.status]}
+                  </span>
+                </span>
+                {run.errorMessage && (
+                  <p className="text-red-400 text-[10px] mt-0.5 max-w-[240px] truncate">
+                    {run.errorMessage}
+                  </p>
+                )}
+              </td>
+              <td className="py-2 pr-4 text-right tabular-nums">
+                {run.status === 'completed' ? totalRowsArchived(run.rowsArchived).toLocaleString() : '—'}
+              </td>
+              <td className="py-2 pr-4 text-zinc-500 truncate max-w-[120px]">
+                {run.triggeredBy === 'cron' ? 'Cron' : `Admin`}
+              </td>
+              <td className="py-2 text-right">
+                {run.status === 'pending_approval' && (
+                  <Button
+                    size="sm"
+                    disabled={isPending}
+                    onClick={() => handleApprove(run.id)}
+                    className="h-6 px-2 text-[10px] bg-yellow-600 hover:bg-yellow-500 text-white"
+                  >
+                    <ShieldCheck className="h-3 w-3 mr-1" />
+                    Approve
+                  </Button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/features/data-retention/components/DataRetentionView.tsx
+++ b/src/features/data-retention/components/DataRetentionView.tsx
@@ -1,0 +1,115 @@
+// DataRetentionView — top-level assembly panel for EPIC 14
+// Combines: retention config form (US-14.2) + archival run history + manual trigger (US-14.1)
+// Rendered on the analytics/admin page; admin-only write, auditor read-only.
+
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Archive, RefreshCw } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/shared/components/ui/card'
+import { Button } from '@/shared/components/ui/button'
+import { cn } from '@/shared/lib/utils'
+import { RetentionConfigForm } from './RetentionConfigForm'
+import { ArchivalRunsTable } from './ArchivalRunsTable'
+import { triggerArchival, fetchArchivalRuns } from '../actions/archival-actions'
+import type { ArchivalRun, RetentionConfig } from '../lib/data-retention-types'
+
+interface DataRetentionViewProps {
+  initialConfig: RetentionConfig
+  initialRuns: ArchivalRun[]
+  readOnly?: boolean
+  className?: string
+}
+
+export function DataRetentionView({
+  initialConfig,
+  initialRuns,
+  readOnly = false,
+  className,
+}: DataRetentionViewProps) {
+  const [runs, setRuns] = useState<ArchivalRun[]>(initialRuns)
+  const [triggerFeedback, setTriggerFeedback] = useState<string | null>(null)
+  const [isTriggerPending, startTriggerTransition] = useTransition()
+  const [isRefreshPending, startRefreshTransition] = useTransition()
+
+  function handleTrigger() {
+    setTriggerFeedback(null)
+    startTriggerTransition(async () => {
+      const result = await triggerArchival()
+      if (result.success) {
+        const total = Object.values(result.rowsArchived ?? {}).reduce((s, n) => s + n, 0)
+        setTriggerFeedback(`Done — ${total.toLocaleString()} rows archived.`)
+      } else {
+        setTriggerFeedback(result.error ?? 'Archival failed.')
+      }
+      // Refresh run list
+      const fresh = await fetchArchivalRuns()
+      if (fresh.success && fresh.data) setRuns(fresh.data)
+    })
+  }
+
+  function handleRefresh() {
+    startRefreshTransition(async () => {
+      const fresh = await fetchArchivalRuns()
+      if (fresh.success && fresh.data) setRuns(fresh.data)
+    })
+  }
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* ── Retention configuration (US-14.2) ── */}
+      {!readOnly && (
+        <Card className="bg-zinc-900 border-zinc-800">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm text-white flex items-center gap-2">
+              <Archive className="h-4 w-4 text-zinc-400" />
+              Data Retention Settings
+            </CardTitle>
+            <CardDescription className="text-xs text-zinc-400">
+              Set how long each data type is kept before being moved to the archive.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <RetentionConfigForm initialConfig={initialConfig} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Archival history + manual trigger (US-14.1) ── */}
+      <Card className="bg-zinc-900 border-zinc-800">
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="text-sm text-white flex items-center gap-2">
+                <Archive className="h-4 w-4 text-zinc-400" />
+                Archival History
+              </CardTitle>
+              <CardDescription className="text-xs text-zinc-400">
+                Runs automatically on the 1st of each month.
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={handleRefresh}
+                disabled={isRefreshPending}
+                className="text-zinc-500 hover:text-zinc-200 h-7 px-2">
+                <RefreshCw className={cn('h-3.5 w-3.5', isRefreshPending && 'animate-spin')} />
+              </Button>
+              {!readOnly && (
+                <Button size="sm" onClick={handleTrigger} disabled={isTriggerPending}
+                  className="h-7 bg-zinc-700 hover:bg-zinc-600 text-zinc-200 text-xs">
+                  {isTriggerPending ? 'Running…' : 'Run Now'}
+                </Button>
+              )}
+            </div>
+          </div>
+          {triggerFeedback && (
+            <p className="text-xs text-blue-400 mt-1">{triggerFeedback}</p>
+          )}
+        </CardHeader>
+        <CardContent>
+          <ArchivalRunsTable runs={runs} onApproved={handleRefresh} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/features/data-retention/components/RetentionConfigForm.tsx
+++ b/src/features/data-retention/components/RetentionConfigForm.tsx
@@ -1,0 +1,136 @@
+// RetentionConfigForm — admin form to set per-data-type retention periods
+// EPIC 14 — US-14.2: Configurable Data Retention
+
+'use client'
+
+import { useState, useTransition } from 'react'
+import { Save } from 'lucide-react'
+import { Button } from '@/shared/components/ui/button'
+import { cn } from '@/shared/lib/utils'
+import { updateRetentionConfig } from '../actions/retention-config-actions'
+import type { RetentionConfig } from '../lib/data-retention-types'
+
+interface RetentionConfigFormProps {
+  initialConfig: RetentionConfig
+}
+
+interface FieldConfig {
+  key: keyof Omit<RetentionConfig, 'requiresApproval'>
+  label: string
+  description: string
+}
+
+const FIELDS: FieldConfig[] = [
+  {
+    key: 'patientAdmissionsYears',
+    label: 'Patient Admissions',
+    description: 'Discharge records in patient_admissions',
+  },
+  {
+    key: 'auditLogsYears',
+    label: 'Audit Logs',
+    description: 'All system audit trail entries',
+  },
+  {
+    key: 'bedStageLogYears',
+    label: 'Bed Stage Logs',
+    description: 'Bed stage transition history',
+  },
+]
+
+const inputClass = cn(
+  'w-20 bg-zinc-800 border border-zinc-700 rounded px-2 py-1',
+  'text-sm text-zinc-200 text-right',
+  'focus:outline-none focus:ring-1 focus:ring-blue-500',
+  'disabled:opacity-50 disabled:cursor-not-allowed',
+)
+
+export function RetentionConfigForm({ initialConfig }: RetentionConfigFormProps) {
+  const [config, setConfig] = useState<RetentionConfig>(initialConfig)
+  const [feedback, setFeedback] = useState<{ ok: boolean; message: string } | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function handleYearChange(key: keyof RetentionConfig, raw: string) {
+    const val = parseInt(raw, 10)
+    setConfig((prev) => ({ ...prev, [key]: isNaN(val) ? 0 : val }))
+  }
+
+  function handleApprovalToggle() {
+    setConfig((prev) => ({ ...prev, requiresApproval: !prev.requiresApproval }))
+  }
+
+  function handleSubmit() {
+    setFeedback(null)
+    startTransition(async () => {
+      const result = await updateRetentionConfig(config)
+      setFeedback(
+        result.success
+          ? { ok: true, message: 'Retention settings saved.' }
+          : { ok: false, message: result.error ?? 'Save failed.' },
+      )
+    })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-3">
+        {FIELDS.map(({ key, label, description }) => (
+          <div key={key} className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm text-zinc-200">{label}</p>
+              <p className="text-xs text-zinc-500">{description}</p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <input
+                type="number"
+                min={1}
+                max={99}
+                value={config[key] as number}
+                onChange={(e) => handleYearChange(key, e.target.value)}
+                disabled={isPending}
+                aria-label={`${label} retention years`}
+                className={inputClass}
+              />
+              <span className="text-xs text-zinc-500 w-8">yr</span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Approval toggle ── */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={config.requiresApproval}
+          onChange={handleApprovalToggle}
+          disabled={isPending}
+          className="w-4 h-4 accent-blue-500"
+        />
+        <div>
+          <p className="text-sm text-zinc-200">Require admin approval before deletion</p>
+          <p className="text-xs text-zinc-500">
+            Cron runs create a pending job; an admin must approve before data is moved.
+          </p>
+        </div>
+      </label>
+
+      <div className="flex items-center gap-3 pt-1">
+        <Button
+          onClick={handleSubmit}
+          disabled={isPending}
+          size="sm"
+          className="bg-blue-600 hover:bg-blue-700 text-white"
+        >
+          <Save className="h-3.5 w-3.5 mr-1.5" />
+          {isPending ? 'Saving…' : 'Save Settings'}
+        </Button>
+
+        {feedback && (
+          <p className={cn('text-xs', feedback.ok ? 'text-green-400' : 'text-red-400')}>
+            {feedback.message}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/data-retention/lib/archival-queries.ts
+++ b/src/features/data-retention/lib/archival-queries.ts
@@ -1,0 +1,42 @@
+// archival-queries.ts — DB helpers for archival_runs table reads
+// EPIC 14 — US-14.1
+
+import { query } from '@/shared/lib/db'
+import type { ArchivalRun, RawArchivalRunRow } from './data-retention-types'
+
+function mapRun(row: RawArchivalRunRow): ArchivalRun {
+  return {
+    id: row.id,
+    triggeredBy: row.triggered_by,
+    status: row.status,
+    cutoffDate: new Date(row.cutoff_date),
+    startedAt: new Date(row.started_at),
+    endedAt: row.ended_at ? new Date(row.ended_at) : null,
+    rowsArchived: row.rows_archived ?? {},
+    errorMessage: row.error_message,
+  }
+}
+
+/** Return the most recent N archival run records for the status card. */
+export async function getRecentArchivalRuns(limit = 5): Promise<ArchivalRun[]> {
+  const result = await query<RawArchivalRunRow>(
+    `SELECT id, triggered_by, status, cutoff_date, started_at, ended_at,
+            rows_archived, error_message
+     FROM archival_runs
+     ORDER BY started_at DESC
+     LIMIT $1`,
+    [limit]
+  )
+  return result.rows.map(mapRun)
+}
+
+/** Return a single run by id — used by the approval flow. */
+export async function getArchivalRunById(runId: string): Promise<ArchivalRun | null> {
+  const result = await query<RawArchivalRunRow>(
+    `SELECT id, triggered_by, status, cutoff_date, started_at, ended_at,
+            rows_archived, error_message
+     FROM archival_runs WHERE id = $1`,
+    [runId]
+  )
+  return result.rows[0] ? mapRun(result.rows[0]) : null
+}

--- a/src/features/data-retention/lib/archival-run-helpers.ts
+++ b/src/features/data-retention/lib/archival-run-helpers.ts
@@ -2,18 +2,23 @@
 // EPIC 14 — US-14.1 (internal, not exported from the feature)
 
 import { query } from '@/shared/lib/db'
-import type { ArchiveTableResult } from './archival-runner'
+import type { ArchiveTableResult, ArchivalCutoffs } from './archival-runner'
+import type { RetentionConfig } from './data-retention-types'
 
 /** Insert a new archival_runs row with status='running' and return its id. */
 export async function createRunRecord(
   triggeredBy: string,
-  cutoffDate: Date,
+  cutoffs: ArchivalCutoffs,
 ): Promise<string> {
+  // Store the earliest cutoff in the log row for display purposes
+  const earliestCutoff = new Date(
+    Math.min(cutoffs.patientAdmissions.getTime(), cutoffs.auditLogs.getTime()),
+  )
   const result = await query<{ id: string }>(
     `INSERT INTO archival_runs (triggered_by, status, cutoff_date)
      VALUES ($1, 'running', $2)
      RETURNING id`,
-    [triggeredBy, cutoffDate],
+    [triggeredBy, earliestCutoff],
   )
   return result.rows[0].id
 }
@@ -55,10 +60,20 @@ export function collectResults(tableResults: ArchiveTableResult[]): {
   return { rowsArchived, errors }
 }
 
-/** Compute the oldest cutoff date from a list of retention periods in years. */
-export function computeCutoffDate(retentionYears: number[]): Date {
-  const minYears = Math.min(...retentionYears)
+/** Subtract years from today and return the resulting Date. */
+function yearsAgo(years: number): Date {
   const d = new Date()
-  d.setFullYear(d.getFullYear() - minYears)
+  d.setFullYear(d.getFullYear() - years)
   return d
+}
+
+/**
+ * Build per-table cutoff dates from the retention config.
+ * Each table uses its own configured retention period — not a shared minimum.
+ */
+export function buildCutoffs(config: RetentionConfig): ArchivalCutoffs {
+  return {
+    patientAdmissions: yearsAgo(config.patientAdmissionsYears),
+    auditLogs: yearsAgo(config.auditLogsYears),
+  }
 }

--- a/src/features/data-retention/lib/archival-run-helpers.ts
+++ b/src/features/data-retention/lib/archival-run-helpers.ts
@@ -1,0 +1,64 @@
+// archival-run-helpers.ts — DB write helpers for archival_runs lifecycle
+// EPIC 14 — US-14.1 (internal, not exported from the feature)
+
+import { query } from '@/shared/lib/db'
+import type { ArchiveTableResult } from './archival-runner'
+
+/** Insert a new archival_runs row with status='running' and return its id. */
+export async function createRunRecord(
+  triggeredBy: string,
+  cutoffDate: Date,
+): Promise<string> {
+  const result = await query<{ id: string }>(
+    `INSERT INTO archival_runs (triggered_by, status, cutoff_date)
+     VALUES ($1, 'running', $2)
+     RETURNING id`,
+    [triggeredBy, cutoffDate],
+  )
+  return result.rows[0].id
+}
+
+/** Mark a run as completed and persist the per-table row counts. */
+export async function finaliseRunRecord(
+  runId: string,
+  rowsArchived: Record<string, number>,
+): Promise<void> {
+  await query(
+    `UPDATE archival_runs
+     SET status = 'completed', ended_at = NOW(), rows_archived = $2
+     WHERE id = $1`,
+    [runId, JSON.stringify(rowsArchived)],
+  )
+}
+
+/** Mark a run as failed and record the error message. */
+export async function failRunRecord(runId: string, message: string): Promise<void> {
+  await query(
+    `UPDATE archival_runs
+     SET status = 'failed', ended_at = NOW(), error_message = $2
+     WHERE id = $1`,
+    [runId, message],
+  )
+}
+
+/** Reduce an array of per-table results into a rows-archived map + error list. */
+export function collectResults(tableResults: ArchiveTableResult[]): {
+  rowsArchived: Record<string, number>
+  errors: string[]
+} {
+  const rowsArchived: Record<string, number> = {}
+  const errors: string[] = []
+  for (const r of tableResults) {
+    rowsArchived[r.table] = r.rowsMoved
+    if (r.error) errors.push(`${r.table}: ${r.error}`)
+  }
+  return { rowsArchived, errors }
+}
+
+/** Compute the oldest cutoff date from a list of retention periods in years. */
+export function computeCutoffDate(retentionYears: number[]): Date {
+  const minYears = Math.min(...retentionYears)
+  const d = new Date()
+  d.setFullYear(d.getFullYear() - minYears)
+  return d
+}

--- a/src/features/data-retention/lib/archival-runner.ts
+++ b/src/features/data-retention/lib/archival-runner.ts
@@ -1,0 +1,120 @@
+// archival-runner.ts — core move-rows logic for EPIC 14 / US-14.1
+//
+// Each table is archived in its own transaction so a failure on one table
+// does not roll back already-completed tables. Rows are moved in batches
+// of BATCH_SIZE to avoid table-level lock contention on a live system.
+
+import pool from '@/shared/lib/db'
+import { logger } from '@/shared/config/logger'
+import type { PoolClient } from 'pg'
+
+const BATCH_SIZE = 500
+
+// ── Per-table archive specs ───────────────────────────────────────────────
+
+interface TableSpec {
+  source: string
+  archive: string
+  /** Column used to compare against the cutoff date */
+  dateColumn: string
+}
+
+const ARCHIVAL_TABLES: TableSpec[] = [
+  {
+    source: 'patient_admissions',
+    archive: 'patient_admissions_archive',
+    dateColumn: 'created_at',
+  },
+  {
+    source: 'audit_logs',
+    archive: 'audit_logs_archive',
+    dateColumn: 'created_at',
+  },
+]
+
+// ── Internal batch helpers ────────────────────────────────────────────────
+
+/**
+ * Move one batch of rows from source → archive within the provided client.
+ * Returns the number of rows moved (0 means we are done for this table).
+ */
+async function archiveBatch(
+  client: PoolClient,
+  spec: TableSpec,
+  cutoffDate: Date,
+): Promise<number> {
+  // CTE: grab up to BATCH_SIZE qualifying IDs, then move them atomically.
+  const sql = `
+    WITH batch AS (
+      SELECT id FROM ${spec.source}
+      WHERE ${spec.dateColumn} < $1
+      LIMIT ${BATCH_SIZE}
+      FOR UPDATE SKIP LOCKED
+    ),
+    moved AS (
+      INSERT INTO ${spec.archive}
+        SELECT s.*, NOW() AS archived_at
+        FROM ${spec.source} s
+        JOIN batch b ON b.id = s.id
+      RETURNING s.id
+    )
+    DELETE FROM ${spec.source}
+    WHERE id IN (SELECT id FROM moved)
+    RETURNING id`
+
+  const result = await client.query(sql, [cutoffDate])
+  return result.rowCount ?? 0
+}
+
+// ── Public runner ─────────────────────────────────────────────────────────
+
+export interface ArchiveTableResult {
+  table: string
+  rowsMoved: number
+  error?: string
+}
+
+/**
+ * Archive all rows older than cutoffDate for all registered tables.
+ * Processes each table independently — a failure on one does not block others.
+ *
+ * @param cutoffDate - Rows with created_at < this date are moved to archive
+ * @returns Per-table results including row counts and any error messages
+ */
+export async function archiveTables(
+  cutoffDate: Date,
+): Promise<ArchiveTableResult[]> {
+  const results: ArchiveTableResult[] = []
+
+  for (const spec of ARCHIVAL_TABLES) {
+    const client = await pool.connect()
+    let totalMoved = 0
+
+    try {
+      // Keep moving batches until none remain
+      let batchCount = 0
+      do {
+        await client.query('BEGIN')
+        batchCount = await archiveBatch(client, spec, cutoffDate)
+        await client.query('COMMIT')
+        totalMoved += batchCount
+      } while (batchCount === BATCH_SIZE)
+
+      logger.info('Archival completed for table', {
+        table: spec.source,
+        rowsMoved: totalMoved,
+        cutoffDate,
+      })
+      results.push({ table: spec.source, rowsMoved: totalMoved })
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => undefined)
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      logger.error('Archival failed for table', err as Error, { table: spec.source })
+      results.push({ table: spec.source, rowsMoved: totalMoved, error: message })
+    } finally {
+      client.release()
+    }
+  }
+
+  return results
+}

--- a/src/features/data-retention/lib/archival-runner.ts
+++ b/src/features/data-retention/lib/archival-runner.ts
@@ -17,6 +17,8 @@ interface TableSpec {
   archive: string
   /** Column used to compare against the cutoff date */
   dateColumn: string
+  /** Key into the RetentionConfig — used to look up the per-table cutoff. */
+  configKey: 'patientAdmissions' | 'auditLogs'
 }
 
 const ARCHIVAL_TABLES: TableSpec[] = [
@@ -24,11 +26,13 @@ const ARCHIVAL_TABLES: TableSpec[] = [
     source: 'patient_admissions',
     archive: 'patient_admissions_archive',
     dateColumn: 'created_at',
+    configKey: 'patientAdmissions',
   },
   {
     source: 'audit_logs',
     archive: 'audit_logs_archive',
     dateColumn: 'created_at',
+    configKey: 'auditLogs',
   },
 ]
 
@@ -56,7 +60,7 @@ async function archiveBatch(
         SELECT s.*, NOW() AS archived_at
         FROM ${spec.source} s
         JOIN batch b ON b.id = s.id
-      RETURNING s.id
+      RETURNING id
     )
     DELETE FROM ${spec.source}
     WHERE id IN (SELECT id FROM moved)
@@ -74,19 +78,26 @@ export interface ArchiveTableResult {
   error?: string
 }
 
+/** Per-table cutoff dates — each table uses its own configured retention period. */
+export interface ArchivalCutoffs {
+  patientAdmissions: Date
+  auditLogs: Date
+}
+
 /**
- * Archive all rows older than cutoffDate for all registered tables.
+ * Archive all rows older than the per-table cutoff dates.
  * Processes each table independently — a failure on one does not block others.
  *
- * @param cutoffDate - Rows with created_at < this date are moved to archive
+ * @param cutoffs - Per-table cutoff Date objects derived from the retention config
  * @returns Per-table results including row counts and any error messages
  */
 export async function archiveTables(
-  cutoffDate: Date,
+  cutoffs: ArchivalCutoffs,
 ): Promise<ArchiveTableResult[]> {
   const results: ArchiveTableResult[] = []
 
   for (const spec of ARCHIVAL_TABLES) {
+    const cutoffDate = cutoffs[spec.configKey]
     const client = await pool.connect()
     let totalMoved = 0
 

--- a/src/features/data-retention/lib/data-retention-types.ts
+++ b/src/features/data-retention/lib/data-retention-types.ts
@@ -1,0 +1,44 @@
+// data-retention-types.ts — shared interfaces for EPIC 14
+// US-14.1: Automated Data Archival
+// US-14.2: Configurable Data Retention
+
+// ── Archival run ───────────────────────────────────────────────────────────
+
+export type ArchivalRunStatus =
+  | 'running'
+  | 'pending_approval'
+  | 'completed'
+  | 'failed'
+
+export interface ArchivalRun {
+  id: string
+  triggeredBy: string   // 'cron' | user_id UUID
+  status: ArchivalRunStatus
+  cutoffDate: Date
+  startedAt: Date
+  endedAt: Date | null
+  rowsArchived: Record<string, number>
+  errorMessage: string | null
+}
+
+/** Raw DB row returned from archival_runs */
+export interface RawArchivalRunRow {
+  id: string
+  triggered_by: string
+  status: ArchivalRunStatus
+  cutoff_date: string
+  started_at: string
+  ended_at: string | null
+  rows_archived: Record<string, number>
+  error_message: string | null
+}
+
+// ── Retention configuration ────────────────────────────────────────────────
+
+/** Per-table retention periods and behaviour settings read from system_settings */
+export interface RetentionConfig {
+  patientAdmissionsYears: number
+  auditLogsYears: number
+  bedStageLogYears: number
+  requiresApproval: boolean
+}

--- a/src/features/data-retention/lib/retention-config-queries.ts
+++ b/src/features/data-retention/lib/retention-config-queries.ts
@@ -1,0 +1,83 @@
+// retention-config-queries.ts — read/write retention settings from system_settings
+// EPIC 14 — US-14.2
+
+import { query } from '@/shared/lib/db'
+import type { RetentionConfig } from './data-retention-types'
+
+const DEFAULTS: RetentionConfig = {
+  patientAdmissionsYears: 7,
+  auditLogsYears: 7,
+  bedStageLogYears: 2,
+  requiresApproval: true,
+}
+
+/**
+ * Read all four retention settings in a single query.
+ * Falls back to safe defaults when a key is missing.
+ */
+export async function getRetentionConfig(): Promise<RetentionConfig> {
+  const result = await query<{ key: string; value: string }>(
+    `SELECT key, value FROM system_settings
+     WHERE key IN (
+       'retention_patient_admissions_years',
+       'retention_audit_logs_years',
+       'retention_bed_stage_log_years',
+       'retention_requires_approval'
+     )`
+  )
+
+  const map = Object.fromEntries(result.rows.map((r) => [r.key, r.value]))
+
+  return {
+    patientAdmissionsYears:
+      parseInt(map['retention_patient_admissions_years'] ?? '', 10) ||
+      DEFAULTS.patientAdmissionsYears,
+    auditLogsYears:
+      parseInt(map['retention_audit_logs_years'] ?? '', 10) ||
+      DEFAULTS.auditLogsYears,
+    bedStageLogYears:
+      parseInt(map['retention_bed_stage_log_years'] ?? '', 10) ||
+      DEFAULTS.bedStageLogYears,
+    requiresApproval:
+      (map['retention_requires_approval'] ?? 'true') !== 'false',
+  }
+}
+
+/**
+ * Upsert all four retention settings atomically.
+ * Each key is updated individually via ON CONFLICT to preserve updated_at.
+ */
+export async function saveRetentionConfig(config: RetentionConfig): Promise<void> {
+  const upsertSql = `
+    INSERT INTO system_settings (key, value, description)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (key) DO UPDATE
+      SET value = EXCLUDED.value, updated_at = NOW()`
+
+  const rows: Array<[string, string, string]> = [
+    [
+      'retention_patient_admissions_years',
+      String(config.patientAdmissionsYears),
+      'Years to retain patient_admissions rows before archiving (EPIC 14)',
+    ],
+    [
+      'retention_audit_logs_years',
+      String(config.auditLogsYears),
+      'Years to retain audit_logs rows before archiving (EPIC 14)',
+    ],
+    [
+      'retention_bed_stage_log_years',
+      String(config.bedStageLogYears),
+      'Years to retain bed_stage_log rows before archiving (EPIC 14)',
+    ],
+    [
+      'retention_requires_approval',
+      config.requiresApproval ? 'true' : 'false',
+      'When true, cron-triggered archival jobs pause for admin approval (EPIC 14)',
+    ],
+  ]
+
+  for (const [key, value, description] of rows) {
+    await query(upsertSql, [key, value, description])
+  }
+}


### PR DESCRIPTION
## Summary

Closes #88 — Automated Data Archival (US-14.1)
Closes #89 — Configurable Retention Periods (US-14.2)

---

## Migrations

- `022_create_archival_tables.sql` — patient_admissions_archive, audit_logs_archive, archival_runs + archival_run_status ENUM
- `023_seed_retention_settings.sql` — seeds 4 default retention keys into system_settings

---

## What was built

**Archival engine**
- archival-runner.ts: moves rows in 500-row batches using FOR UPDATE SKIP LOCKED CTE, per-table independent transactions, per-table cutoff dates

**Retention config**
- retention-config-queries.ts: read/write 4 retention keys from system_settings
- retention-config-actions.ts: fetchRetentionConfig, updateRetentionConfig (admin-only write)

**Run lifecycle**
- archival-run-helpers.ts: createRunRecord, finaliseRunRecord, failRunRecord, collectResults, buildCutoffs

**Server actions**
- archival-actions.ts: triggerArchival, approveArchival, fetchArchivalRuns

**Cron route**
- GET /api/cron/archival — protected by CRON_SECRET bearer token
- Approval gate: when retention_requires_approval = true, cron creates a pending_approval run; admin approves in the UI

**UI (bottom of /analytics page)**
- DataRetentionView, RetentionConfigForm, ArchivalRunsTable
- Admin: config form + manual trigger + approve pending runs
- Auditor: read-only run history only

---

## Critical Bug Fixes

**BUG 1** — `RETURNING s.id` is invalid SQL in the archival CTE.
PostgreSQL rejects alias-qualified column refs in RETURNING. Every archival run would crash with `missing FROM-clause entry for table "s"`.
Fixed: `RETURNING s.id` → `RETURNING id`

**BUG 2** — Single cutoff date applied to all tables.
`Math.min()` across all retention years caused audit_logs to be archived at the bed_stage_log period (2y) instead of its own (7y), silently violating the configured retention policy.
Fixed: `archiveTables()` now accepts `ArchivalCutoffs { patientAdmissions: Date, auditLogs: Date }`; `buildCutoffs(config)` derives per-table dates from the retention config.

---

## Code Quality
- All files ≤ 200 lines (CONTRIBUTING.md enforced)
- Zero TypeScript errors (`tsc --noEmit`)
- Parameterised queries throughout — no SQL injection surface
- All writes audited via `logAudit()` for compliance trail