### PR TITLE
feat: add print-friendly view for analytics page (US-11.4)

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,51 +1,17 @@
-import { StageAnalyticsView } from '@/features/bed-dashboard/components/StageAnalyticsView'
-import { AuditorHistoryView } from '@/features/bed-dashboard/components/AuditorHistoryView'
-import { TatAnalyticsView } from '@/features/bed-dashboard/components/TatAnalyticsView'
-import { LosView } from '@/features/bed-dashboard/components/LosView'
-import { PatientCountView } from '@/features/management-report/components/PatientCountView'
-import { DelayedPatientPercentageView } from '@/features/management-report/components/DelayedPatientPercentageView'
-import { BedPerformanceView } from '@/features/management-report/components/BedPerformanceView'
-import { StageDelayView } from '@/features/management-report/components/StageDelayView'
-import { ShiftReportView } from '@/features/shift-management/components/ShiftReportView'
-import { ShiftComparisonView } from '@/features/shift-management/components/ShiftComparisonView'
-import { DataRetentionView } from '@/features/data-retention/components/DataRetentionView'
+import { verifyActiveSession } from '@/shared/lib/active-session'
+import { redirect } from 'next/navigation'
+import { logAudit } from '@/shared/lib/audit'
 import { getShifts } from '@/features/shift-management/lib/shift-queries'
 import { getRetentionConfig } from '@/features/data-retention/lib/retention-config-queries'
 import { getRecentArchivalRuns } from '@/features/data-retention/lib/archival-queries'
-import { StaffingHeatmap } from '@/features/bed-dashboard/components/StaffingHeatmap'
-import { verifyActiveSession } from '@/shared/lib/active-session'
-import { redirect } from 'next/navigation'
-import { Button } from '@/shared/components/ui/button'
-import { ArrowLeft } from 'lucide-react'
-import Link from 'next/link'
-import { logAudit } from '@/shared/lib/audit'
-import { LogoutButton } from '@/features/auth/components/LogoutButton'
-import { ExportReportButton } from '@/features/export/components/ExportReportButton'
-import type { PdfSection } from '@/features/export/types/export.types'
-
-// All sections available for the full-report PDF (US-11.1)
-const FULL_REPORT_SECTIONS: PdfSection[] = [
-  { exportId: 'export-stage-analytics',  title: 'Stage Analytics' },
-  { exportId: 'export-auditor-history',  title: 'Bed Stage Change History' },
-  { exportId: 'export-tat',             title: 'Full-Cycle Bed Turnaround' },
-  { exportId: 'export-los',             title: 'Average Length of Stay' },
-  { exportId: 'export-patients',        title: 'Total Patients Treated' },
-  { exportId: 'export-delayed',         title: 'Delayed Patients %' },
-  { exportId: 'export-beds',            title: 'Bed-Wise Performance' },
-  { exportId: 'export-stages',          title: 'Stage-Wise Delays' },
-  { exportId: 'export-shift-report',    title: 'Shift Performance Report' },
-  { exportId: 'export-shift-comparison',title: 'Shift Performance Comparison' },
-  { exportId: 'export-heatmap',         title: 'Staffing Heatmap' },
-]
+import { AnalyticsPageContent } from '@/features/bed-dashboard/components/AnalyticsPageContent'
+import '@/app/analytics/print.css'
 
 export default async function AnalyticsPage() {
   const session = await verifyActiveSession()
 
-  if (!session) {
-    redirect('/login')
-  }
+  if (!session) redirect('/login')
 
-  // Only supervisor, admin, and auditor can view analytics
   if (session.role !== 'supervisor' && session.role !== 'admin' && session.role !== 'auditor') {
     redirect('/dashboard')
   }
@@ -60,13 +26,10 @@ export default async function AnalyticsPage() {
         entityId: 'analytics-dashboard',
         performedBy: session.userId,
         reason: 'Auditor accessed analytics in read-only mode',
-        metadata: {
-          role: session.role,
-          mode: 'read-only',
-        },
+        metadata: { role: session.role, mode: 'read-only' },
       })
     } catch {
-      // Non-blocking log path for analytics visibility
+      // Non-blocking
     }
   }
 
@@ -76,122 +39,26 @@ export default async function AnalyticsPage() {
       ? '/admin'
       : '/analytics'
 
-  // Fetch active shifts server-side so they can be passed to client components
-  // that need a shift selector (US-10.1, US-8.3).
   let activeShifts: Awaited<ReturnType<typeof getShifts>> = []
   try {
     activeShifts = await getShifts()
   } catch {
-    // Non-blocking: components will render with an empty shift list gracefully
+    // Non-blocking
   }
 
-  // EPIC 14: Retention config + recent archival runs — admin and auditor only
   const isRetentionVisible = session.role === 'admin' || session.role === 'auditor'
   const retentionConfig = isRetentionVisible ? await getRetentionConfig().catch(() => null) : null
   const archivalRuns   = isRetentionVisible ? await getRecentArchivalRuns(10).catch(() => []) : []
 
   return (
-    <div className="min-h-screen bg-black text-foreground p-8">
-      <div className="max-w-7xl mx-auto space-y-8">
-        {/* Header */}
-        <div className="flex items-center gap-4">
-          {isAuditMode ? (
-            <LogoutButton />
-          ) : (
-            <Link href={backHref}>
-              <Button variant="ghost" size="sm" className="gap-2">
-                <ArrowLeft className="h-4 w-4" />
-                Back
-              </Button>
-            </Link>
-          )}
-          <div className="flex-1">
-            <h1 className="text-3xl font-bold tracking-tight text-white">
-              Emergency Ward Analytics
-            </h1>
-            <p className="text-zinc-400">Analyze patient flow through treatment stages</p>
-            {isAuditMode && (
-              <div className="mt-2 inline-flex items-center rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-200">
-                Audit Mode: Read-Only Access
-              </div>
-            )}
-          </div>
-          {/* EPIC 11 (US-11.1): Full-report export button */}
-          <ExportReportButton
-            scope="full"
-            pdfSections={FULL_REPORT_SECTIONS}
-            pdfTitle="Emergency Ward Analytics Report"
-            exportedBy={session.username}
-            label="Export Full Report"
-            size="sm"
-            variant="outline"
-          />
-        </div>
-
-        {/* Analytics View (US-3.x: Stage duration + bed timeline) */}
-        <div data-export-id="export-stage-analytics">
-          <StageAnalyticsView readOnly={isAuditMode} />
-        </div>
-
-        {/* EPIC 12: Auditor read-only stage history */}
-        <div data-export-id="export-auditor-history">
-          <AuditorHistoryView readOnly={isAuditMode} />
-        </div>
-
-        {/* Turnaround Time Analytics (US-2.4) */}
-        <div data-export-id="export-tat">
-          <TatAnalyticsView readOnly={isAuditMode} />
-        </div>
-
-        {/* ── Management Report Dashboard ───────────────────────────────── */}
-
-        {/* Average Length of Stay (EPIC 10 / US-10.x) */}
-        <div data-export-id="export-los">
-          <LosView role={session.role} readOnly={isAuditMode} />
-        </div>
-
-        {/* Total Patients Treated (US-10.1) — data-export-id on component root */}
-        <PatientCountView shifts={activeShifts} readOnly={isAuditMode} />
-
-        {/* ── US-10.3: Percentage of Delayed Patients ──────────────────── */}
-        <DelayedPatientPercentageView
-          shifts={activeShifts}
-          readOnly={isAuditMode}
-          role={session.role}
-        />
-
-        {/* ── US-10.4: Bed-Wise Performance ────────────────────────────── */}
-        <BedPerformanceView shifts={activeShifts} readOnly={isAuditMode} />
-
-        {/* ── US-10.5: Stage-Wise Delays ───────────────────────────────── */}
-        <StageDelayView readOnly={isAuditMode} />
-
-        {/* Shift Performance Report (US-8.3) */}
-        {activeShifts.length > 0 && (
-          <div data-export-id="export-shift-report">
-            <ShiftReportView shifts={activeShifts} readOnly={isAuditMode} />
-          </div>
-        )}
-
-        {/* Shift Performance Comparison (US-8.4) */}
-        <div data-export-id="export-shift-comparison">
-          <ShiftComparisonView readOnly={isAuditMode} />
-        </div>
-
-        {/* ── Data Retention & Archival (EPIC 14 / US-14.1, US-14.2) ───── */}
-        {isRetentionVisible && retentionConfig && (
-          <DataRetentionView
-            initialConfig={retentionConfig}
-            initialRuns={archivalRuns}
-            readOnly={isAuditMode}
-          />
-        )}
-
-        {/* Staffing Heatmap — EPIC 10: patient volume by hour and day of week */}
-        <div data-export-id="export-heatmap">
-          <StaffingHeatmap />
-        </div>
-      </div>
-    </div>
+    <AnalyticsPageContent
+      isAuditMode={isAuditMode}
+      backHref={backHref}
+      username={session.username}
+      role={session.role}
+      activeShifts={activeShifts}
+      retentionConfig={retentionConfig}
+      archivalRuns={archivalRuns}
+    />
   )
 }

--- a/src/app/analytics/print.css
+++ b/src/app/analytics/print.css
@@ -1,0 +1,102 @@
+@media print {
+
+  @page {
+    size: A4 portrait;
+    margin: 16mm 14mm 16mm 14mm;
+  }
+
+  /* Hide non-print elements */
+  .print\:hidden,
+  nav,
+  aside,
+  footer {
+    display: none !important;
+  }
+
+  /* Hide all buttons in print */
+  button {
+    display: none !important;
+  }
+
+  /* Reset background for print */
+  * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  html, body {
+    background: #ffffff !important;
+    color: #111111 !important;
+    font-size: 11pt;
+  }
+
+  .min-h-screen {
+    min-height: unset !important;
+    background: #ffffff !important;
+    padding: 0 !important;
+  }
+
+  .max-w-7xl {
+    max-width: 100% !important;
+    margin: 0 !important;
+  }
+
+  /* Text colors */
+  h1, h2, h3, h4, h5, h6 { color: #111111 !important; }
+  p, span, td, th, li { color: #333333 !important; }
+
+  /* Card backgrounds */
+  [class*="bg-zinc"],
+  [class*="bg-black"],
+  [class*="bg-gray"] {
+    background: #f8f8f8 !important;
+    border: 1px solid #dddddd !important;
+  }
+
+  /* Page breaks */
+  .print-section {
+    break-before: page;
+    page-break-before: always;
+  }
+
+  .print-no-break {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Tables */
+  table { border-collapse: collapse; width: 100%; }
+  thead { display: table-header-group; }
+  th {
+    background: #eeeeee !important;
+    color: #111111 !important;
+    font-weight: 700;
+    border: 1px solid #cccccc !important;
+    padding: 6px 10px;
+  }
+  td {
+    border: 1px solid #dddddd !important;
+    padding: 5px 10px;
+  }
+  tr {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Print-only header */
+  .print-header {
+    display: block !important;
+    text-align: center;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 2px solid #111111;
+  }
+
+  .print-header h1 { font-size: 18pt; font-weight: 700; margin: 0 0 4px 0; }
+  .print-header p { font-size: 10pt; color: #555555 !important; margin: 0; }
+
+  /* Remove overflow restrictions */
+  [class*="overflow"] { overflow: visible !important; }
+}

--- a/src/features/bed-dashboard/components/AnalyticsPageContent.tsx
+++ b/src/features/bed-dashboard/components/AnalyticsPageContent.tsx
@@ -1,0 +1,148 @@
+import { StageAnalyticsView } from '@/features/bed-dashboard/components/StageAnalyticsView'
+import { AuditorHistoryView } from '@/features/bed-dashboard/components/AuditorHistoryView'
+import { TatAnalyticsView } from '@/features/bed-dashboard/components/TatAnalyticsView'
+import { LosView } from '@/features/bed-dashboard/components/LosView'
+import { PatientCountView } from '@/features/management-report/components/PatientCountView'
+import { DelayedPatientPercentageView } from '@/features/management-report/components/DelayedPatientPercentageView'
+import { BedPerformanceView } from '@/features/management-report/components/BedPerformanceView'
+import { StageDelayView } from '@/features/management-report/components/StageDelayView'
+import { ShiftReportView } from '@/features/shift-management/components/ShiftReportView'
+import { ShiftComparisonView } from '@/features/shift-management/components/ShiftComparisonView'
+import { DataRetentionView } from '@/features/data-retention/components/DataRetentionView'
+import { StaffingHeatmap } from '@/features/bed-dashboard/components/StaffingHeatmap'
+import { ExportReportButton } from '@/features/export/components/ExportReportButton'
+import { LogoutButton } from '@/features/auth/components/LogoutButton'
+import { PrintButton } from '@/features/bed-dashboard/components/PrintButton'
+import { Button } from '@/shared/components/ui/button'
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
+import type { PdfSection } from '@/features/export/types/export.types'
+import type { getShifts } from '@/features/shift-management/lib/shift-queries'
+import type { getRetentionConfig } from '@/features/data-retention/lib/retention-config-queries'
+import type { getRecentArchivalRuns } from '@/features/data-retention/lib/archival-queries'
+
+const FULL_REPORT_SECTIONS: PdfSection[] = [
+  { exportId: 'export-stage-analytics',   title: 'Stage Analytics' },
+  { exportId: 'export-auditor-history',   title: 'Bed Stage Change History' },
+  { exportId: 'export-tat',              title: 'Full-Cycle Bed Turnaround' },
+  { exportId: 'export-los',              title: 'Average Length of Stay' },
+  { exportId: 'export-patients',         title: 'Total Patients Treated' },
+  { exportId: 'export-delayed',          title: 'Delayed Patients %' },
+  { exportId: 'export-beds',             title: 'Bed-Wise Performance' },
+  { exportId: 'export-stages',           title: 'Stage-Wise Delays' },
+  { exportId: 'export-shift-report',     title: 'Shift Performance Report' },
+  { exportId: 'export-shift-comparison', title: 'Shift Performance Comparison' },
+  { exportId: 'export-heatmap',          title: 'Staffing Heatmap' },
+]
+
+interface Props {
+  isAuditMode: boolean
+  backHref: string
+  username: string
+  role: string
+  activeShifts: Awaited<ReturnType<typeof getShifts>>
+  retentionConfig: Awaited<ReturnType<typeof getRetentionConfig>> | null
+  archivalRuns: Awaited<ReturnType<typeof getRecentArchivalRuns>>
+}
+
+export function AnalyticsPageContent({
+  isAuditMode,
+  backHref,
+  username,
+  role,
+  activeShifts,
+  retentionConfig,
+  archivalRuns,
+}: Props) {
+  const printDate = new Date().toLocaleDateString('en-IN', {
+    day: '2-digit', month: 'long', year: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  })
+
+  const isRetentionVisible = role === 'admin' || role === 'auditor'
+
+  return (
+    <div className="min-h-screen bg-black text-foreground p-8">
+      <div className="max-w-7xl mx-auto space-y-8">
+
+        {/* US-11.4: Print-only header */}
+        <div className="print-header hidden">
+          <h1>JMCH Emergency Ward – Analytics Report</h1>
+          <p>Generated on {printDate}</p>
+        </div>
+
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          {isAuditMode ? <LogoutButton /> : (
+            <Link href={backHref}>
+              <Button variant="ghost" size="sm" className="gap-2">
+                <ArrowLeft className="h-4 w-4" />Back
+              </Button>
+            </Link>
+          )}
+          <div className="flex-1">
+            <h1 className="text-3xl font-bold tracking-tight text-white">Emergency Ward Analytics</h1>
+            <p className="text-zinc-400">Analyze patient flow through treatment stages</p>
+            {isAuditMode && (
+              <div className="mt-2 inline-flex items-center rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-xs font-medium text-amber-200">
+                Audit Mode: Read-Only Access
+              </div>
+            )}
+          </div>
+          <PrintButton />
+          <ExportReportButton
+            scope="full"
+            pdfSections={FULL_REPORT_SECTIONS}
+            pdfTitle="Emergency Ward Analytics Report"
+            exportedBy={username}
+            label="Export Full Report"
+            size="sm"
+            variant="outline"
+          />
+        </div>
+
+        <div data-export-id="export-stage-analytics" className="print-no-break">
+          <StageAnalyticsView readOnly={isAuditMode} />
+        </div>
+        <div data-export-id="export-auditor-history" className="print-section print-no-break">
+          <AuditorHistoryView readOnly={isAuditMode} />
+        </div>
+        <div data-export-id="export-tat" className="print-section print-no-break">
+          <TatAnalyticsView readOnly={isAuditMode} />
+        </div>
+        <div data-export-id="export-los" className="print-section print-no-break">
+          <LosView role={role} readOnly={isAuditMode} />
+        </div>
+        <div className="print-section print-no-break">
+          <PatientCountView shifts={activeShifts} readOnly={isAuditMode} />
+        </div>
+        <div className="print-section print-no-break">
+          <DelayedPatientPercentageView shifts={activeShifts} readOnly={isAuditMode} role={role} />
+        </div>
+        <div className="print-section print-no-break">
+          <BedPerformanceView shifts={activeShifts} readOnly={isAuditMode} />
+        </div>
+        <div className="print-section print-no-break">
+          <StageDelayView readOnly={isAuditMode} />
+        </div>
+        {activeShifts.length > 0 && (
+          <div data-export-id="export-shift-report" className="print-section print-no-break">
+            <ShiftReportView shifts={activeShifts} readOnly={isAuditMode} />
+          </div>
+        )}
+        <div data-export-id="export-shift-comparison" className="print-section print-no-break">
+          <ShiftComparisonView readOnly={isAuditMode} />
+        </div>
+        {isRetentionVisible && retentionConfig && (
+          <div className="print-section print-no-break">
+            <DataRetentionView initialConfig={retentionConfig} initialRuns={archivalRuns} readOnly={isAuditMode} />
+          </div>
+        )}
+        <div data-export-id="export-heatmap" className="print-section print-no-break">
+          <StaffingHeatmap />
+        </div>
+
+      </div>
+    </div>
+  )
+}

--- a/src/features/bed-dashboard/components/PrintButton.tsx
+++ b/src/features/bed-dashboard/components/PrintButton.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Printer } from 'lucide-react'
+import { Button } from '@/shared/components/ui/button'
+
+export function PrintButton() {
+  const handlePrint = () => {
+    window.print()
+  }
+
+  return (
+    <Button
+      onClick={handlePrint}
+      variant="outline"
+      size="sm"
+      className="gap-2 border-zinc-700 text-zinc-300 hover:text-white hover:border-zinc-500 print:hidden"
+    >
+      <Printer className="h-4 w-4" />
+      Print View
+    </Button>
+  )
+}


### PR DESCRIPTION
## Description
Added print-friendly view for the Emergency Ward Analytics page. Users can now click the "Print View" button to open a browser print dialog with a clean, A4-optimized layout that hides navigation, buttons, and unnecessary UI elements.

## Linked Issue
Closes #70

## Type
- [x] Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Refactor
- [ ] Test

## Checklist

### Code Quality
- [x] No file exceeds 200 lines (except lock files: package-lock.json, yarn.lock, pnpm-lock.yaml)
- [x] Code is properly formatted
- [x] TypeScript types are properly defined
- [x] No ESLint errors or warnings

### Testing
- [x] Tested locally and works as expected
- [ ] Added/updated tests if applicable
- [x] All existing tests pass
- [ ] EPIC 13 reliability verification completed (manual/staging) per `docs/EPIC13_VERIFICATION_CHECKLIST.md` (if applicable)

### Database & Environment
- [ ] Database migrations tested (if applicable)
- [ ] Migration rollback tested (if applicable)
- [ ] Environment variables documented in .env.example (if new vars added)
- [ ] Database schema changes documented (if applicable)
- [x] No modifications to existing migration files

### Documentation
- [x] Code comments added for complex logic
- [ ] README updated (if setup process changed)
- [ ] DATABASE_SETUP.md updated (if database changes)

### UI/UX (if applicable)
- [x] Screenshots attached (if UI changes)
- [x] Responsive design tested
- [x] Accessibility considerations addressed

## Screenshots
<img width="1904" height="1012" alt="Screenshot 2026-02-21 102000" src="https://github.com/user-attachments/assets/4d183dcd-5293-461a-b7f3-8118d05a92db" />
