### PR TITLE
feat(supervisor): add delayed bed count banner with color coding (US-15.2) #93

### DIFF
--- a/src/features/bed-dashboard/components/DelayedBedCountBanner.tsx
+++ b/src/features/bed-dashboard/components/DelayedBedCountBanner.tsx
@@ -1,0 +1,77 @@
+// DelayedBedCountBanner.tsx
+// US-15.x: Prominent delayed bed count with color coding and click-to-filter
+// Epic 15: Notifications & Alerts
+
+'use client'
+
+import { AlertTriangle, CheckCircle, Clock } from 'lucide-react'
+
+interface DelayedBedCountBannerProps {
+  delayedCount: number
+  onFilterDelayed: () => void
+  isFiltered: boolean
+}
+
+function getBannerStyle(count: number) {
+  if (count === 0) return {
+    bg: 'bg-green-950/40',
+    border: 'border-green-800/50',
+    text: 'text-green-400',
+    label: 'text-green-300',
+    icon: <CheckCircle className="h-8 w-8 text-green-400" />,
+    message: 'All patients on track',
+  }
+  if (count <= 2) return {
+    bg: 'bg-yellow-950/40',
+    border: 'border-yellow-800/50',
+    text: 'text-yellow-400',
+    label: 'text-yellow-300',
+    icon: <Clock className="h-8 w-8 text-yellow-400" />,
+    message: 'Requires attention',
+  }
+  return {
+    bg: 'bg-red-950/40',
+    border: 'border-red-800/50',
+    text: 'text-red-400',
+    label: 'text-red-300',
+    icon: <AlertTriangle className="h-8 w-8 text-red-400" />,
+    message: 'Immediate action needed',
+  }
+}
+
+export function DelayedBedCountBanner({
+  delayedCount,
+  onFilterDelayed,
+  isFiltered,
+}: DelayedBedCountBannerProps) {
+  const style = getBannerStyle(delayedCount)
+
+  return (
+    <button
+      type="button"
+      onClick={onFilterDelayed}
+      className={`w-full rounded-lg border ${style.bg} ${style.border} p-4 
+        flex items-center justify-between gap-4 
+        hover:opacity-90 transition-opacity cursor-pointer
+        ${isFiltered ? 'ring-2 ring-offset-1 ring-offset-black ring-white/20' : ''}`}
+    >
+      <div className="flex items-center gap-4">
+        {style.icon}
+        <div className="text-left">
+          <p className={`text-xs uppercase tracking-wider font-semibold ${style.label}`}>
+            Delayed Beds
+          </p>
+          <p className={`text-4xl font-bold ${style.text}`}>
+            {delayedCount}
+          </p>
+          <p className={`text-xs ${style.label} mt-0.5`}>
+            {style.message}
+          </p>
+        </div>
+      </div>
+      <div className={`text-xs font-medium px-3 py-1.5 rounded-full border ${style.border} ${style.label}`}>
+        {isFiltered ? 'Show All Beds' : 'View Delayed Only'}
+      </div>
+    </button>
+  )
+}

--- a/src/features/bed-dashboard/components/SupervisorBedOverview.tsx
+++ b/src/features/bed-dashboard/components/SupervisorBedOverview.tsx
@@ -1,6 +1,7 @@
 // Supervisor Bed Overview Component
 // Epic 1: Nurse Desk Bed Dashboard (US-1.7)
 // Epic 6: Surge Capacity (US-6.5)
+// Epic 15: Notifications & Alerts (US-15.x)
 // Purpose: Read-only bed status view for supervisors — shows delays,
 //   bottleneck beds, and recorded reasons for delay.
 //   Supervisors can also add and remove temporary beds.
@@ -12,6 +13,7 @@ import { BedGridStats } from './BedGridStats'
 import { BedStatusLegend } from './BedStatusLegend'
 import { BottleneckPanel } from './BottleneckPanel'
 import { BedCard } from './BedCard'
+import { DelayedBedCountBanner } from './DelayedBedCountBanner'
 import { Button } from '@/shared/components/ui/button'
 import { RefreshCw, Zap, Trash2 } from 'lucide-react'
 import type { BedGridData } from '../types/bed'
@@ -41,6 +43,7 @@ export function SupervisorBedOverview({
 }: SupervisorBedOverviewProps) {
   const [data, setData] = useState<BedGridData>(initialData)
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [showDelayedOnly, setShowDelayedOnly] = useState(false)
   const [, startTransition] = useTransition()
 
   // US-6.5: when the shell re-fetches and passes new initialData, sync local state
@@ -81,6 +84,14 @@ export function SupervisorBedOverview({
 
   return (
     <div className="space-y-6">
+
+      {/* US-15.x: Prominent delayed bed count banner with color coding + click-to-filter */}
+      <DelayedBedCountBanner
+        delayedCount={delayedBeds.length}
+        onFilterDelayed={() => setShowDelayedOnly(prev => !prev)}
+        isFiltered={showDelayedOnly}
+      />
+
       {/* Stats */}
       <BedGridStats
         total={stats.total}
@@ -155,8 +166,8 @@ export function SupervisorBedOverview({
       {/* Bottleneck panel — supervisor can see + trigger refresh after update */}
       <BottleneckPanel beds={data.beds} onReasonRecorded={handleRefresh} />
 
-      {/* Delayed / bottleneck bed cards (read-only — no stage update controls) */}
-      {delayedBeds.length > 0 && (
+      {/* US-15.x: Delayed / bottleneck bed cards — shown when filter is active */}
+      {showDelayedOnly && delayedBeds.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wider">
@@ -180,7 +191,7 @@ export function SupervisorBedOverview({
         </div>
       )}
 
-      {delayedBeds.length === 0 && (
+      {showDelayedOnly && delayedBeds.length === 0 && (
         <div className="rounded-lg border border-zinc-800 bg-zinc-900/30 py-10 text-center">
           <p className="text-zinc-400">🎉 No delayed beds — all patients are on track.</p>
         </div>


### PR DESCRIPTION
## Description
Adds a prominent delayed bed count banner on the supervisor dashboard (US-15.2).

**Changes:**
- New `DelayedBedCountBanner.tsx` component with color-coded severity:
  - 🟢 Green: 0 delayed beds (All patients on track)
  - 🟡 Yellow: 1-2 delayed beds (Requires attention)
  - 🔴 Red: 3+ delayed beds (Immediate action needed)
- Click-to-filter toggle: "View Delayed Only" / "Show All Beds"
- Updated `SupervisorBedOverview.tsx` to include banner at top

## Linked Issue
Closes #93

## Type
- [x] Feature

## Checklist

### Code Quality
- [x] No file exceeds 200 lines
- [x] Code is properly formatted
- [x] TypeScript types are properly defined
- [ ] No ESLint errors or warnings

### Testing
- [x] Tested locally and works as expected
- [x] Added/updated tests if applicable
- [x] All existing tests pass

### Database & Environment

- [ ]  Database migrations tested (if applicable)
- [x] No modifications to existing migration files

### Documentation
- [ ] Updated documentation if needed
- [x] Code comments added for complex logic

### UI/UX (if applicable)
- [x] Screenshots attached (if UI changes)
- [x] Responsive design tested
- [x] Accessibility considerations addressed

## Screenshots
<img width="1904" height="1012" alt="Screenshot 2026-02-21 112235" src="https://github.com/user-attachments/assets/ee8bfe2d-ce4f-405c-baf8-63ab1702ec13" />
