### PR TITLE
Feature/us 23.1 ot room dashboard

### DIFF
--- a/migrations/045_create_ot_rooms.sql
+++ b/migrations/045_create_ot_rooms.sql
@@ -1,0 +1,35 @@
+-- Migration 045: OT Room Occupancy (US-23.1, EPIC-23)
+-- Creates 16 dedicated OT rooms with Available/Ongoing status
+
+-- Up Migration
+
+CREATE TYPE ot_room_status AS ENUM ('available', 'ongoing');
+
+CREATE TABLE IF NOT EXISTS ot_rooms (
+  id            UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  room_number   TEXT NOT NULL UNIQUE,
+  status        ot_room_status NOT NULL DEFAULT 'available',
+  started_at    TIMESTAMP WITH TIME ZONE,
+  updated_by    UUID REFERENCES users(id),
+  updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ot_rooms_status ON ot_rooms(status);
+
+-- Seed OT-01 to OT-16
+INSERT INTO ot_rooms (room_number, status) VALUES
+  ('OT-01', 'available'), ('OT-02', 'available'),
+  ('OT-03', 'available'), ('OT-04', 'available'),
+  ('OT-05', 'available'), ('OT-06', 'available'),
+  ('OT-07', 'available'), ('OT-08', 'available'),
+  ('OT-09', 'available'), ('OT-10', 'available'),
+  ('OT-11', 'available'), ('OT-12', 'available'),
+  ('OT-13', 'available'), ('OT-14', 'available'),
+  ('OT-15', 'available'), ('OT-16', 'available')
+ON CONFLICT (room_number) DO NOTHING;
+
+-- Down Migration
+
+DROP TABLE IF EXISTS ot_rooms;
+DROP TYPE IF EXISTS ot_room_status;

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/bcryptjs": "^2.4.6",
         "@types/html2canvas": "^0.5.35",
         "@types/node": "^20",
         "@types/nprogress": "^0.2.3",
@@ -3704,6 +3705,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/bcryptjs": "^2.4.6",
     "@types/html2canvas": "^0.5.35",
     "@types/node": "^20",
     "@types/nprogress": "^0.2.3",

--- a/src/app/ot/page.tsx
+++ b/src/app/ot/page.tsx
@@ -1,0 +1,65 @@
+// OT Room Occupancy Dashboard Page
+// EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
+
+import { verifyActiveSession } from '@/shared/lib/active-session'
+import { OTDashboardContainer } from '@/features/ot-dashboard/components/OTDashboardContainer'
+import { LogoutButton } from '@/features/auth/components/LogoutButton'
+import { redirect } from 'next/navigation'
+import { Suspense } from 'react'
+import { Activity } from 'lucide-react'
+
+export const dynamic = 'force-dynamic'
+
+function OTSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      {Array.from({ length: 16 }).map((_, i) => (
+        <div
+          key={i}
+          className="rounded-xl border-2 border-border bg-muted/20 p-4 h-28 animate-pulse"
+        />
+      ))}
+    </div>
+  )
+}
+
+export default async function OTDashboardPage() {
+  const session = await verifyActiveSession()
+
+  if (!session) {
+    redirect('/api/auth/force-logout')
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground p-3 sm:p-8">
+      <div className="max-w-7xl mx-auto space-y-6">
+
+        {/* Header */}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-blue-900/20 border border-blue-900/50 rounded-lg">
+              <Activity className="h-6 w-6 text-blue-500" />
+            </div>
+            <div>
+              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-foreground">
+                OT Room Occupancy
+              </h1>
+              <p className="text-muted-foreground text-sm">
+                Real-time status of all 16 Operation Theatre rooms
+              </p>
+            </div>
+          </div>
+          <div className="self-end sm:self-auto flex items-center gap-4">
+            <LogoutButton />
+          </div>
+        </div>
+
+        {/* OT Dashboard */}
+        <Suspense fallback={<OTSkeleton />}>
+          <OTDashboardContainer />
+        </Suspense>
+
+      </div>
+    </div>
+  )
+}

--- a/src/features/ot-dashboard/actions/ot-actions.ts
+++ b/src/features/ot-dashboard/actions/ot-actions.ts
@@ -1,0 +1,81 @@
+'use server'
+
+// OT Dashboard Actions
+// EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
+
+import pool from '@/shared/lib/db'
+import { requireWriteRole } from '@/shared/lib/auth'
+import { logger } from '@/shared/config/logger'
+import type { OTRoom, OTGridData } from '../types/ot'
+
+/** Fetch all 16 OT rooms with current status */
+export async function getOTRooms(): Promise<{ success: boolean; data?: OTGridData; error?: string }> {
+  try {
+    const result = await pool.query<{
+      id: string
+      room_number: string
+      status: 'available' | 'ongoing'
+      started_at: Date | null
+      updated_at: Date
+    }>(
+      `SELECT id, room_number, status, started_at, updated_at
+       FROM ot_rooms
+       ORDER BY room_number ASC`
+    )
+
+    const rooms: OTRoom[] = result.rows.map(r => ({
+      id: r.id,
+      roomNumber: r.room_number,
+      status: r.status,
+      startedAt: r.started_at,
+      updatedAt: r.updated_at,
+    }))
+
+    return {
+      success: true,
+      data: {
+        rooms,
+        availableCount: rooms.filter(r => r.status === 'available').length,
+        ongoingCount: rooms.filter(r => r.status === 'ongoing').length,
+      },
+    }
+  } catch (error) {
+    logger.error('Failed to fetch OT rooms', error as Error)
+    return { success: false, error: 'Failed to load OT rooms' }
+  }
+}
+
+/** Update OT room status (Ongoing / Available) */
+export async function updateOTRoomStatus(input: {
+  roomId: string
+  status: 'available' | 'ongoing'
+}): Promise<{ success: boolean; error?: string }> {
+  try {
+    const session = await requireWriteRole(['nurse', 'supervisor', 'admin'], {
+      actionType: 'UPDATE',
+      entityType: 'ot_room',
+      entityId: input.roomId,
+    })
+
+    await pool.query(
+      `UPDATE ot_rooms
+       SET status     = $1,
+           started_at = CASE WHEN $1 = 'ongoing' THEN NOW() ELSE NULL END,
+           updated_by = $2,
+           updated_at = NOW()
+       WHERE id = $3`,
+      [input.status, session.userId, input.roomId]
+    )
+
+    logger.info('OT room status updated', {
+      roomId: input.roomId,
+      status: input.status,
+      updatedBy: session.userId,
+    })
+
+    return { success: true }
+  } catch (error) {
+    logger.error('Failed to update OT room status', error as Error)
+    return { success: false, error: 'Failed to update room status' }
+  }
+}

--- a/src/features/ot-dashboard/components/OTDashboardClient.tsx
+++ b/src/features/ot-dashboard/components/OTDashboardClient.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+// OT Dashboard Client Component
+// EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
+
+import { useState, useEffect, useCallback } from 'react'
+import { Activity, CheckCircle } from 'lucide-react'
+import { OTRoomCard } from './OTRoomCard'
+import { getOTRooms } from '../actions/ot-actions'
+import type { OTGridData } from '../types/ot'
+
+const POLL_INTERVAL_MS = 15000 // 15 seconds like ER grid
+
+interface OTDashboardClientProps {
+  initialData: OTGridData
+}
+
+export function OTDashboardClient({ initialData }: OTDashboardClientProps) {
+  const [data, setData] = useState<OTGridData>(initialData)
+  const [lastUpdated, setLastUpdated] = useState(new Date())
+
+  const refresh = useCallback(async () => {
+    const result = await getOTRooms()
+    if (result.success && result.data) {
+      setData(result.data)
+      setLastUpdated(new Date())
+    }
+  }, [])
+
+  // Polling — same pattern as ER dashboard
+  useEffect(() => {
+    const interval = setInterval(refresh, POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [refresh])
+
+  return (
+    <div className="space-y-6">
+
+      {/* Stats Bar */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-xs text-muted-foreground">Total Rooms</p>
+          <p className="text-2xl font-bold text-foreground">{data.rooms.length}</p>
+        </div>
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4">
+          <div className="flex items-center gap-2">
+            <CheckCircle className="h-4 w-4 text-emerald-500" />
+            <p className="text-xs text-emerald-600 dark:text-emerald-400">Available</p>
+          </div>
+          <p className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
+            {data.availableCount}
+          </p>
+        </div>
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+          <div className="flex items-center gap-2">
+            <Activity className="h-4 w-4 text-red-500" />
+            <p className="text-xs text-red-600 dark:text-red-400">Ongoing</p>
+          </div>
+          <p className="text-2xl font-bold text-red-600 dark:text-red-400">
+            {data.ongoingCount}
+          </p>
+        </div>
+      </div>
+
+      {/* OT Room Grid — 4 columns like ER */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+        {data.rooms.map(room => (
+          <OTRoomCard
+            key={room.id}
+            room={room}
+            onStatusChange={refresh}
+          />
+        ))}
+      </div>
+
+      {/* Last updated */}
+      <p className="text-xs text-muted-foreground text-right">
+        Last updated: {lastUpdated.toLocaleTimeString()} · Auto-refreshes every 15s
+      </p>
+    </div>
+  )
+}

--- a/src/features/ot-dashboard/components/OTDashboardClient.tsx
+++ b/src/features/ot-dashboard/components/OTDashboardClient.tsx
@@ -9,7 +9,7 @@ import { OTRoomCard } from './OTRoomCard'
 import { getOTRooms } from '../actions/ot-actions'
 import type { OTGridData } from '../types/ot'
 
-const POLL_INTERVAL_MS = 15000 // 15 seconds like ER grid
+const POLL_INTERVAL_MS = 15000
 
 interface OTDashboardClientProps {
   initialData: OTGridData
@@ -17,7 +17,7 @@ interface OTDashboardClientProps {
 
 export function OTDashboardClient({ initialData }: OTDashboardClientProps) {
   const [data, setData] = useState<OTGridData>(initialData)
-  const [lastUpdated, setLastUpdated] = useState(new Date())
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
   const refresh = useCallback(async () => {
     const result = await getOTRooms()
@@ -27,7 +27,6 @@ export function OTDashboardClient({ initialData }: OTDashboardClientProps) {
     }
   }, [])
 
-  // Polling — same pattern as ER dashboard
   useEffect(() => {
     const interval = setInterval(refresh, POLL_INTERVAL_MS)
     return () => clearInterval(interval)
@@ -35,8 +34,6 @@ export function OTDashboardClient({ initialData }: OTDashboardClientProps) {
 
   return (
     <div className="space-y-6">
-
-      {/* Stats Bar */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <div className="rounded-lg border border-border bg-card p-4">
           <p className="text-xs text-muted-foreground">Total Rooms</p>
@@ -62,7 +59,6 @@ export function OTDashboardClient({ initialData }: OTDashboardClientProps) {
         </div>
       </div>
 
-      {/* OT Room Grid — 4 columns like ER */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
         {data.rooms.map(room => (
           <OTRoomCard
@@ -73,9 +69,10 @@ export function OTDashboardClient({ initialData }: OTDashboardClientProps) {
         ))}
       </div>
 
-      {/* Last updated */}
       <p className="text-xs text-muted-foreground text-right">
-        Last updated: {lastUpdated.toLocaleTimeString()} · Auto-refreshes every 15s
+        {lastUpdated
+          ? `Last updated: ${lastUpdated.toLocaleTimeString()} · Auto-refreshes every 15s`
+          : 'Auto-refreshes every 15s'}
       </p>
     </div>
   )

--- a/src/features/ot-dashboard/components/OTDashboardContainer.tsx
+++ b/src/features/ot-dashboard/components/OTDashboardContainer.tsx
@@ -1,0 +1,22 @@
+// OT Dashboard Container Component
+// EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
+
+import { AlertTriangle } from 'lucide-react'
+import { getOTRooms } from '../actions/ot-actions'
+import { OTDashboardClient } from './OTDashboardClient'
+
+export async function OTDashboardContainer() {
+  const result = await getOTRooms()
+
+  if (!result.success || !result.data) {
+    return (
+      <div className="rounded-lg border border-destructive bg-destructive/20 p-8 text-center">
+        <AlertTriangle className="h-12 w-12 text-destructive mx-auto mb-4" />
+        <p className="text-destructive font-semibold mb-2">Failed to load OT rooms</p>
+        <p className="text-muted-foreground text-sm">{result.error}</p>
+      </div>
+    )
+  }
+
+  return <OTDashboardClient initialData={result.data} />
+}

--- a/src/features/ot-dashboard/components/OTRoomCard.tsx
+++ b/src/features/ot-dashboard/components/OTRoomCard.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+// OT Room Card Component
+// EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
+
+import { useState } from 'react'
+import { cn } from '@/shared/lib/utils'
+import type { OTRoom } from '../types/ot'
+import { updateOTRoomStatus } from '../actions/ot-actions'
+
+interface OTRoomCardProps {
+  room: OTRoom
+  onStatusChange?: () => void
+}
+
+function formatElapsed(startedAt: Date | null): string {
+  if (!startedAt) return ''
+  const ms = Date.now() - new Date(startedAt).getTime()
+  const mins = Math.floor(ms / 60000)
+  const hrs = Math.floor(mins / 60)
+  if (hrs > 0) return `${hrs}h ${mins % 60}m`
+  return `${mins}m`
+}
+
+export function OTRoomCard({ room, onStatusChange }: OTRoomCardProps) {
+  const [loading, setLoading] = useState(false)
+
+  const isOngoing = room.status === 'ongoing'
+
+  async function handleToggle() {
+    setLoading(true)
+    const newStatus = isOngoing ? 'available' : 'ongoing'
+    await updateOTRoomStatus({ roomId: room.id, status: newStatus })
+    setLoading(false)
+    onStatusChange?.()
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border-2 p-4 flex flex-col gap-3 transition-all duration-200',
+        isOngoing
+          ? 'border-red-500 bg-red-500/10'
+          : 'border-emerald-500 bg-emerald-500/10'
+      )}
+    >
+      {/* Room Number */}
+      <div className="flex items-center justify-between">
+        <span className="text-lg font-bold text-foreground">{room.roomNumber}</span>
+        <span
+          className={cn(
+            'text-xs font-semibold px-2 py-0.5 rounded-full',
+            isOngoing
+              ? 'bg-red-500 text-white'
+              : 'bg-emerald-500 text-white'
+          )}
+        >
+          {isOngoing ? 'Ongoing' : 'Available'}
+        </span>
+      </div>
+
+      {/* Elapsed time for ongoing */}
+      {isOngoing && room.startedAt && (
+        <p className="text-xs text-red-400 font-mono">
+          Duration: {formatElapsed(room.startedAt)}
+        </p>
+      )}
+
+      {/* Toggle Button */}
+      <button
+        onClick={handleToggle}
+        disabled={loading}
+        className={cn(
+          'w-full rounded-lg py-1.5 text-xs font-semibold transition-colors disabled:opacity-50',
+          isOngoing
+            ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
+            : 'bg-red-600 hover:bg-red-700 text-white'
+        )}
+      >
+        {loading ? 'Updating...' : isOngoing ? 'Mark Available' : 'Mark Ongoing'}
+      </button>
+    </div>
+  )
+}

--- a/src/features/ot-dashboard/components/OTRoomCard.tsx
+++ b/src/features/ot-dashboard/components/OTRoomCard.tsx
@@ -3,7 +3,7 @@
 // OT Room Card Component
 // EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
 
-import { useState } from 'react'
+import { useState, useTransition } from 'react'
 import { cn } from '@/shared/lib/utils'
 import type { OTRoom } from '../types/ot'
 import { updateOTRoomStatus } from '../actions/ot-actions'
@@ -23,16 +23,30 @@ function formatElapsed(startedAt: Date | null): string {
 }
 
 export function OTRoomCard({ room, onStatusChange }: OTRoomCardProps) {
-  const [loading, setLoading] = useState(false)
+  const [optimisticStatus, setOptimisticStatus] = useState(room.status)
+  const [optimisticStartedAt, setOptimisticStartedAt] = useState(room.startedAt)
+  const [isPending, startTransition] = useTransition()
 
-  const isOngoing = room.status === 'ongoing'
+  const isOngoing = optimisticStatus === 'ongoing'
 
   async function handleToggle() {
-    setLoading(true)
     const newStatus = isOngoing ? 'available' : 'ongoing'
-    await updateOTRoomStatus({ roomId: room.id, status: newStatus })
-    setLoading(false)
-    onStatusChange?.()
+
+    // Optimistic update — UI changes immediately
+    setOptimisticStatus(newStatus)
+    setOptimisticStartedAt(newStatus === 'ongoing' ? new Date() : null)
+
+    const result = await updateOTRoomStatus({ roomId: room.id, status: newStatus })
+
+    if (!result.success) {
+      // Revert on error
+      setOptimisticStatus(room.status)
+      setOptimisticStartedAt(room.startedAt)
+    } else {
+      startTransition(() => {
+        onStatusChange?.()
+      })
+    }
   }
 
   return (
@@ -44,7 +58,6 @@ export function OTRoomCard({ room, onStatusChange }: OTRoomCardProps) {
           : 'border-emerald-500 bg-emerald-500/10'
       )}
     >
-      {/* Room Number */}
       <div className="flex items-center justify-between">
         <span className="text-lg font-bold text-foreground">{room.roomNumber}</span>
         <span
@@ -59,17 +72,15 @@ export function OTRoomCard({ room, onStatusChange }: OTRoomCardProps) {
         </span>
       </div>
 
-      {/* Elapsed time for ongoing */}
-      {isOngoing && room.startedAt && (
+      {isOngoing && optimisticStartedAt && (
         <p className="text-xs text-red-400 font-mono">
-          Duration: {formatElapsed(room.startedAt)}
+          Duration: {formatElapsed(optimisticStartedAt)}
         </p>
       )}
 
-      {/* Toggle Button */}
       <button
         onClick={handleToggle}
-        disabled={loading}
+        disabled={isPending}
         className={cn(
           'w-full rounded-lg py-1.5 text-xs font-semibold transition-colors disabled:opacity-50',
           isOngoing
@@ -77,7 +88,7 @@ export function OTRoomCard({ room, onStatusChange }: OTRoomCardProps) {
             : 'bg-red-600 hover:bg-red-700 text-white'
         )}
       >
-        {loading ? 'Updating...' : isOngoing ? 'Mark Available' : 'Mark Ongoing'}
+        {isPending ? 'Updating...' : isOngoing ? 'Mark Available' : 'Mark Ongoing'}
       </button>
     </div>
   )

--- a/src/features/ot-dashboard/types/ot.ts
+++ b/src/features/ot-dashboard/types/ot.ts
@@ -1,0 +1,18 @@
+// OT Dashboard Types
+// EPIC 23: Operation Theatre (OT) Tracking Module (US-23.1)
+
+export type OTRoomStatus = 'available' | 'ongoing'
+
+export interface OTRoom {
+  id: string
+  roomNumber: string
+  status: OTRoomStatus
+  startedAt: Date | null
+  updatedAt: Date
+}
+
+export interface OTGridData {
+  rooms: OTRoom[]
+  availableCount: number
+  ongoingCount: number
+}


### PR DESCRIPTION
## Description
Fixed OT room status toggle UI — added optimistic updates so room card 
changes color instantly on click without waiting for server response.
Status reverts automatically if server call fails.

## Linked Issue
Closes #261

## Type
- [x] Feature
- [x] Bugfix

## Checklist
- [x] No file exceeds 200 lines
- [x] TypeScript types properly defined
- [x] No ESLint errors or warnings
- [x] Tested locally — status toggle working
- [x] All existing tests pass
- [x] Database migration tested (045)
- [x] No modifications to existing migrations

## Changes Made
- `migrations/045_create_ot_rooms.sql` — ot_rooms table + 16 seeded rooms
- `src/features/ot-dashboard/types/ot.ts` — OTRoom TypeScript types
- `src/features/ot-dashboard/actions/ot-actions.ts` — getOTRooms + updateOTRoomStatus
- `src/features/ot-dashboard/components/OTRoomCard.tsx` — optimistic status toggle
- `src/features/ot-dashboard/components/OTDashboardClient.tsx` — 15s polling, hydration fix
- `src/features/ot-dashboard/components/OTDashboardContainer.tsx` — server container
- `src/app/ot/page.tsx` — /ot route, distinct from ER dashboard

## Acceptance Criteria Met
- ✅ 16 OT rooms grid (OT-01 to OT-16)
- ✅ Real-time status (Ongoing / Available) with instant UI feedback
- ✅ Distinct from ER dashboard (/ot route)
- ✅ 15s polling like ER Grid