### PR TITLE
fix(db1-02): clear bed demographics only after successful discharge a…

### DIFF
--- a/src/features/bed-dashboard/__tests__/bed-mutations.constants.test.ts
+++ b/src/features/bed-dashboard/__tests__/bed-mutations.constants.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+
+import { UPDATE_BED_STAGE_SQL } from '../lib/bed-mutations.constants'
+
+describe('UPDATE_BED_STAGE_SQL demographics safety', () => {
+  it('does not clear patient demographics in shared stage updates', () => {
+    const sql = UPDATE_BED_STAGE_SQL
+
+    expect(sql).not.toMatch(/patient_uhid\s*=\s*CASE/i)
+    expect(sql).not.toMatch(/patient_ipd_id\s*=\s*CASE/i)
+    expect(sql).not.toMatch(/patient_name\s*=\s*CASE/i)
+    expect(sql).not.toMatch(/patient_age\s*=\s*CASE/i)
+    expect(sql).not.toMatch(/patient_gender\s*=\s*CASE/i)
+    expect(sql).not.toMatch(/key_symptom\s*=\s*CASE/i)
+    expect(sql).not.toMatch(/triage_category\s*=\s*CASE/i)
+    expect(sql).not.toContain("metadata - 'triageInfo'")
+  })
+})

--- a/src/features/bed-dashboard/__tests__/discharge-queries.test.ts
+++ b/src/features/bed-dashboard/__tests__/discharge-queries.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { archiveAndResetBed } from '../lib/discharge-queries'
+
+const NOW = new Date('2026-03-15T10:00:00.000Z')
+const ADMITTED_AT = new Date('2026-03-15T08:30:00.000Z')
+
+describe('archiveAndResetBed', () => {
+  it('clears demographics only after archival insert succeeds', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // prev discharge
+      .mockResolvedValueOnce({ rows: [{ id: 'adm-1' }] }) // insert admission
+      .mockResolvedValueOnce({}) // reset bed
+      .mockResolvedValueOnce({}) // close delay reasons
+
+    const client = { query } as never
+
+    await archiveAndResetBed(client, {
+      bedId: 'bed-1',
+      admittedAt: ADMITTED_AT,
+      now: NOW,
+      totalDurationMs: NOW.getTime() - ADMITTED_AT.getTime(),
+      cleaningStageId: 'stage-clean',
+      userId: 'user-1',
+      notes: null,
+    })
+
+    const updateSql = query.mock.calls[2][0] as string
+
+    expect(updateSql).toMatch(/patient_start_time\s*=\s*NULL/)
+    expect(updateSql).toMatch(/patient_uhid\s*=\s*NULL/)
+    expect(updateSql).toMatch(/patient_ipd_id\s*=\s*NULL/)
+    expect(updateSql).toMatch(/patient_name\s*=\s*NULL/)
+    expect(updateSql).toMatch(/patient_age\s*=\s*NULL/)
+    expect(updateSql).toMatch(/patient_gender\s*=\s*NULL/)
+    expect(updateSql).toMatch(/key_symptom\s*=\s*NULL/)
+    expect(updateSql).toMatch(/triage_category\s*=\s*NULL/)
+    expect(updateSql).toContain("metadata           = metadata - 'triageInfo'")
+  })
+})

--- a/src/features/bed-dashboard/actions/__tests__/discharge-actions.test.ts
+++ b/src/features/bed-dashboard/actions/__tests__/discharge-actions.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/shared/lib/auth', () => ({ requireWriteRole: vi.fn() }))
+vi.mock('@/shared/lib/audit', () => ({ logAudit: vi.fn() }))
+vi.mock('@/shared/config/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/shared/lib/db', () => ({
+  default: { connect: vi.fn() },
+}))
+vi.mock('@/shared/lib/pii-detector', () => ({
+  detectPii: vi.fn(() => ({ hasPii: false, summary: '' })),
+  redactPii: vi.fn((value: string) => value),
+}))
+vi.mock('../../lib/bed-queries', () => ({ checkWardAccess: vi.fn() }))
+vi.mock('../../lib/discharge-queries', () => ({
+  fetchBedForDischarge: vi.fn(),
+  fetchDischargeStages: vi.fn(),
+  insertDischargeLogs: vi.fn(),
+  archiveAndResetBed: vi.fn(),
+}))
+
+import pool from '@/shared/lib/db'
+import { requireWriteRole } from '@/shared/lib/auth'
+import { checkWardAccess } from '../../lib/bed-queries'
+import {
+  fetchBedForDischarge,
+  fetchDischargeStages,
+  insertDischargeLogs,
+  archiveAndResetBed,
+} from '../../lib/discharge-queries'
+import { dischargeAndResetBed } from '../discharge-actions'
+
+const BED = {
+  id: 'bed-1',
+  currentStageId: 'stage-triage',
+  currentStageName: 'Triage',
+  patientStartTime: new Date('2026-03-15T08:00:00.000Z'),
+  lastStageChange: new Date('2026-03-15T08:05:00.000Z'),
+  isOccupied: true,
+}
+
+const STAGES = {
+  dischargeStage: { id: 'stage-discharge', name: 'Discharge Process' },
+  cleaningStage: { id: 'stage-clean', name: 'Cleaning' },
+}
+
+describe('dischargeAndResetBed failure safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rolls back and does not reset bed when discharge logs fail', async () => {
+    vi.mocked(requireWriteRole).mockResolvedValue({ userId: 'u-1', role: 'nurse' } as never)
+    vi.mocked(checkWardAccess).mockResolvedValue(null)
+    vi.mocked(fetchBedForDischarge).mockResolvedValue(BED)
+    vi.mocked(fetchDischargeStages).mockResolvedValue(STAGES)
+    vi.mocked(insertDischargeLogs).mockRejectedValue(new Error('insert failed'))
+
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce(undefined) // ROLLBACK
+
+    const release = vi.fn()
+    vi.mocked(pool.connect).mockResolvedValueOnce({ query, release } as never)
+
+    const result = await dischargeAndResetBed({ bedId: 'bed-1', notes: 'ok' })
+
+    expect(result.success).toBe(false)
+    expect(insertDischargeLogs).toHaveBeenCalledOnce()
+    expect(archiveAndResetBed).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith('ROLLBACK')
+    const sqls = query.mock.calls.map(([sql]) => String(sql))
+    expect(sqls.some((sql) => sql.includes('UPDATE beds'))).toBe(false)
+    expect(release).toHaveBeenCalled()
+  })
+})

--- a/src/features/bed-dashboard/lib/bed-mutations.constants.ts
+++ b/src/features/bed-dashboard/lib/bed-mutations.constants.ts
@@ -44,17 +44,6 @@ export const UPDATE_BED_STAGE_SQL = `
         ELSE patient_start_time
       END,
       is_occupied = $3,
-      patient_uhid = CASE WHEN $2 THEN NULL ELSE patient_uhid END,
-      patient_ipd_id = CASE WHEN $2 THEN NULL ELSE patient_ipd_id END,
-      patient_name = CASE WHEN $2 THEN NULL ELSE patient_name END,
-      patient_age = CASE WHEN $2 THEN NULL ELSE patient_age END,
-      patient_gender = CASE WHEN $2 THEN NULL ELSE patient_gender END,
-      key_symptom = CASE WHEN $2 THEN NULL ELSE key_symptom END,
-      triage_category = CASE WHEN $2 THEN NULL ELSE triage_category END,
-      metadata = CASE 
-        WHEN $2 THEN metadata - 'triageInfo'
-        ELSE metadata
-      END,
       updated_at = NOW()
   WHERE id = $4
   RETURNING patient_start_time as "patientStartTime", is_occupied as "isOccupied", last_stage_change as "lastStageChange"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Description
Fixes DB1-02 by ensuring patient demographic fields are cleared only after a successful discharge archive. The shared stage update SQL no longer nulls demographics, and discharge reset remains the single point of clearing. Added regression tests for failure safety and success-path clearing.

## Linked Issue
Closes #291 

## Type
- [ ] Feature
- [x] Bugfix
- [ ] Documentation
- [ ] Refactor
- [x] Test

## Checklist

### Code Quality
- [x] No file exceeds 200 lines (except lock files)
- [x] Code is properly formatted
- [x] TypeScript types are properly defined
- [x] No ESLint errors or warnings

### Testing
- [x] Tested locally and works as expected
- [x] Added/updated tests if applicable
- [x] All existing tests pass
- [ ] EPIC 13 reliability verification completed (not applicable)

### Database & Environment
- [x] Database migrations tested (not applicable)
- [x] Migration rollback tested (not applicable)
- [x] Environment variables documented in .env.example (not applicable)
- [x] Database schema changes documented (not applicable)
- [x] No modifications to existing migration files

### Documentation
- [ ] Updated documentation if needed (not required)
- [ ] ADMIN_HANDBOOK.md updated (not required)
- [ ] README updated (not required)
- [ ] DATABASE_SETUP.md updated (not required)
- [x] Code comments added for complex logic (not needed)

### UI/UX (if applicable)
- [x] Screenshots attached (not applicable)
- [x] Responsive design tested (not applicable)
- [x] Accessibility considerations addressed (not applicable)

## Screenshots
N/A