### PR TITLE
feat(triage): implement triage management features

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -182,8 +182,15 @@ This PR introduces the following migration files; ensure they are reviewed and, 
 - migrations/050_remove_triage_from_er.sql
 - migrations/055_seed_emergency_ward.sql
 - migrations/062_us25_2_er_stage_repair.sql
+- migrations/1775303000000_create_triage_workflow.sql
 
 If these migrations alter table structures or seed critical data, update the "Detailed Setup" and any operational runbooks (docs/ADMIN_HANDBOOK.md) with steps required for deployment and rollback.
+
+`1775303000000_create_triage_workflow.sql` adds the dedicated triage state model:
+- `triage_bed_state` enum with `empty`, `initial_treatment`, `decision_made`, and `cleaning`
+- `triage_bed_statuses` for current triage bed state
+- `triage_state_logs` for immutable triage state history
+- six active physical triage beds: `TRIAGE-01` through `TRIAGE-06`
 
 
 ### Step 4: Seed Initial Data

--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -6,7 +6,7 @@ Administrator runbook for configuration, maintenance, backup/recovery, security,
 - Owner: Platform / System Administration
 - Scope: Configuration, backups, troubleshooting, security, command references
 - Versioning: Git-tracked; update required in release PRs when operations change
-- Last Updated: 2026-05-20 (EPIC 25 ER Bed Workflow Triage Removal - deactivating legacy triage stages)
+- Last Updated: 2026-05-21 (EPIC 25 Dedicated Triage Workflow)
 
 > **Release-specific operational notes** are in [ADMIN_HANDBOOK_RELEASES.md](./ADMIN_HANDBOOK_RELEASES.md).
 
@@ -95,6 +95,33 @@ npm run validate:schema
 3. Test login as admin and one non-admin role.
 4. Confirm recent audit entries are queryable.
 5. Record drill date, backup artifact, and outcome in ops notes.
+
+## 3A) Dedicated Triage Workflow Operations
+
+Migration `1775303000000_create_triage_workflow.sql` adds the dedicated triage
+state model for the physical Triage Area.
+
+### What Changed
+- Adds enum `triage_bed_state` with `empty`, `initial_treatment`, `decision_made`, and `cleaning`.
+- Adds `triage_bed_statuses` for each triage bed's current state.
+- Adds `triage_state_logs` for immutable triage state history.
+- Ensures ward code `TRIAGE` exists and keeps exactly six active physical beds: `TRIAGE-01` through `TRIAGE-06`.
+- Deactivates any extra beds assigned to the `TRIAGE` ward that are not part of the approved six-bed layout.
+
+### Apply the Migration
+```bash
+npm run db:migrate
+npm run validate:migrations
+npm run validate:schema
+npm run build
+```
+
+### Administrator Actions
+1. Before production deployment, confirm no intentional extra beds are assigned to ward code `TRIAGE`; the migration marks extras inactive.
+2. After migration, open `/triage` and verify six beds are visible.
+3. Confirm triage shows only the approved states: Empty, Initial Treatment, Decision Made, Cleaning.
+4. Verify assignment and state movement are audit logged with `entity_type = 'triage_bed'`.
+5. Keep ER stage configuration separate; do not add ER-only stages to the triage workflow.
 
 ## 4) Troubleshooting (Common Issues)
 

--- a/docs/DATABASE_SCHEMA_EASY.md
+++ b/docs/DATABASE_SCHEMA_EASY.md
@@ -17,6 +17,7 @@ The database is organized into these areas:
 4. System configuration
 5. Data retention and archive
 6. OT room tracking
+7. Dedicated triage area tracking
 
 ## 2) Core Tables (Most Important)
 
@@ -56,6 +57,17 @@ One row per completed admission/discharge cycle.
 Defines which stage-to-stage moves are allowed.
 - Key fields: `from_stage_id`, `to_stage_id`, `is_allowed`, `requires_supervisor_override`
 - Enforces workflow rules centrally
+
+### `triage_bed_statuses`
+Current state for the six physical triage beds.
+- Key fields: `bed_id`, `state`, `last_state_change`
+- State values: `empty`, `initial_treatment`, `decision_made`, `cleaning`
+- Design rule: independent from ER `stages`
+
+### `triage_state_logs`
+Immutable history of triage state changes.
+- Key fields: `bed_id`, `from_state`, `to_state`, `changed_by_user_id`, `transition_time`
+- Used with `audit_logs` for triage workflow traceability
 
 ### `disposition_delay_reasons`
 Captures delay reasons at disposition points.

--- a/docs/DATABASE_TABLES_1_10.md
+++ b/docs/DATABASE_TABLES_1_10.md
@@ -160,6 +160,42 @@ Defines valid workflow transitions between stages.
 
 ---
 
+## 6A. `triage_bed_statuses`
+
+Current triage-specific state for each physical triage bed.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `bed_id` | UUID | PK, FK â†’ beds(id) ON DELETE CASCADE | Triage bed reference |
+| `state` | triage_bed_state ENUM | NOT NULL, DEFAULT empty | `empty`, `initial_treatment`, `decision_made`, or `cleaning` |
+| `last_state_change` | TIMESTAMPTZ | NOT NULL | Last triage state transition time |
+| `updated_at` | TIMESTAMPTZ | NOT NULL | Last row update time |
+| `metadata` | JSONB | NOT NULL, DEFAULT '{}' | Triage workflow metadata |
+
+**Indexes:** `idx_triage_statuses_state`
+
+---
+
+## 6B. `triage_state_logs`
+
+Immutable historical log of triage bed state transitions.
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | UUID | PK | Primary key |
+| `bed_id` | UUID | FK â†’ beds(id) ON DELETE CASCADE, NOT NULL | Triage bed reference |
+| `from_state` | triage_bed_state ENUM | | Previous triage state |
+| `to_state` | triage_bed_state ENUM | NOT NULL | New triage state |
+| `changed_by_user_id` | UUID | FK â†’ users(id), NOT NULL | Who made the change |
+| `transition_time` | TIMESTAMPTZ | NOT NULL, DEFAULT CURRENT_TIMESTAMP | When transition happened |
+| `duration_in_previous_state_ms` | BIGINT | | Time in previous triage state |
+| `notes` | TEXT | | Transition notes |
+| `metadata` | JSONB | NOT NULL, DEFAULT '{}' | Extra workflow context |
+
+**Indexes:** `idx_triage_logs_bed_id`, `idx_triage_logs_transition_time`, `idx_triage_logs_user`
+
+---
+
 ## 7. `audit_logs`
 
 Generic audit trail for all entity changes.

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -19,7 +19,7 @@ Migrations live in `migrations/` and are run in **lexicographic filename order**
 
 ---
 
-## Full Migration Inventory (74 files)
+## Full Migration Inventory (80 files)
 
 | File | Purpose |
 |------|---------|
@@ -93,6 +93,7 @@ Migrations live in `migrations/` and are run in **lexicographic filename order**
 | `1773855000000_seed_triage_area_beds.sql` | Seeds Triage Area ward and beds |
 | `1774000000000_enforce_symptom_40_char_limit_after_triage.sql` | Re-enforces 40-char symptom constraint after triage columns added |
 | `1774239900000_ot_procedure_tracking_constraints.sql` | surgeon_id made nullable; unique index for one active OT per room |
+| `1775303000000_create_triage_workflow.sql` | Dedicated triage state model: `triage_bed_state`, `triage_bed_statuses`, `triage_state_logs`, and six active TRIAGE beds |
 
 ---
 

--- a/docs/TRIAGE_WORKFLOW.md
+++ b/docs/TRIAGE_WORKFLOW.md
@@ -1,0 +1,30 @@
+# Dedicated Triage Workflow
+
+EPIC 25 models triage as a separate physical area with six beds:
+`TRIAGE-01` through `TRIAGE-06`.
+
+Triage bed state is not stored in the ER `stages` workflow. The approved
+triage states are:
+
+- `empty`
+- `initial_treatment`
+- `decision_made`
+- `cleaning`
+
+Allowed transitions:
+
+- `empty -> initial_treatment` when a patient is assigned.
+- `initial_treatment -> decision_made` after assessment and treatment.
+- `decision_made -> cleaning` after the triage decision is completed.
+- `cleaning -> empty` after cleaning is complete.
+
+ER-only stages such as `initial investigation`, `drugs/test`, `observation`,
+and `discharge process` must not appear in triage.
+
+## Database Notes
+
+- `triage_bed_statuses` stores the current triage state per triage bed.
+- `triage_state_logs` stores immutable triage state history.
+- Patient snapshot fields remain on `beds` for this story.
+- Every triage state mutation also writes an `audit_logs` row with
+  `entity_type = 'triage_bed'`.

--- a/migrations/1775303000000_create_triage_workflow.sql
+++ b/migrations/1775303000000_create_triage_workflow.sql
@@ -1,0 +1,105 @@
+-- Migration 1775303000000: Dedicated triage bed workflow
+-- Purpose: EPIC 25 - model triage as a separate 6-bed physical area.
+
+DO $$ BEGIN
+  CREATE TYPE triage_bed_state AS ENUM (
+    'empty',
+    'initial_treatment',
+    'decision_made',
+    'cleaning'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS triage_bed_statuses (
+  bed_id UUID PRIMARY KEY REFERENCES beds(id) ON DELETE CASCADE,
+  state triage_bed_state NOT NULL DEFAULT 'empty',
+  last_state_change TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS triage_state_logs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  bed_id UUID NOT NULL REFERENCES beds(id) ON DELETE CASCADE,
+  from_state triage_bed_state,
+  to_state triage_bed_state NOT NULL,
+  changed_by_user_id UUID NOT NULL REFERENCES users(id),
+  transition_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  duration_in_previous_state_ms BIGINT,
+  notes TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS idx_triage_statuses_state
+  ON triage_bed_statuses(state);
+CREATE INDEX IF NOT EXISTS idx_triage_logs_bed_id
+  ON triage_state_logs(bed_id);
+CREATE INDEX IF NOT EXISTS idx_triage_logs_transition_time
+  ON triage_state_logs(transition_time);
+CREATE INDEX IF NOT EXISTS idx_triage_logs_user
+  ON triage_state_logs(changed_by_user_id);
+
+INSERT INTO wards (name, code, description, is_active)
+VALUES ('Triage Area', 'TRIAGE', 'Dedicated initial assessment area', true)
+ON CONFLICT (code) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    is_active = true,
+    updated_at = CURRENT_TIMESTAMP;
+
+WITH triage_ward AS (
+  SELECT id, name FROM wards WHERE code = 'TRIAGE' LIMIT 1
+), empty_stage AS (
+  SELECT id FROM stages WHERE name = 'Empty' LIMIT 1
+), target_beds(bed_number) AS (
+  VALUES
+    ('TRIAGE-01'), ('TRIAGE-02'), ('TRIAGE-03'),
+    ('TRIAGE-04'), ('TRIAGE-05'), ('TRIAGE-06')
+)
+INSERT INTO beds (
+  bed_number, current_stage_id, last_stage_change, is_occupied, is_active,
+  ward_id, ward_name, metadata, is_temporary, is_virtual
+)
+SELECT
+  tb.bed_number, es.id, CURRENT_TIMESTAMP, false, true,
+  tw.id, tw.name, '{}'::jsonb, false, false
+FROM target_beds tb
+CROSS JOIN triage_ward tw
+CROSS JOIN empty_stage es
+ON CONFLICT (bed_number) DO UPDATE
+SET ward_id = EXCLUDED.ward_id,
+    ward_name = EXCLUDED.ward_name,
+    is_active = true,
+    is_temporary = false,
+    is_virtual = false,
+    updated_at = CURRENT_TIMESTAMP;
+
+WITH triage_ward AS (
+  SELECT id FROM wards WHERE code = 'TRIAGE' LIMIT 1
+), target_beds(bed_number) AS (
+  VALUES
+    ('TRIAGE-01'), ('TRIAGE-02'), ('TRIAGE-03'),
+    ('TRIAGE-04'), ('TRIAGE-05'), ('TRIAGE-06')
+)
+UPDATE beds
+SET is_active = false,
+    updated_at = CURRENT_TIMESTAMP
+WHERE ward_id = (SELECT id FROM triage_ward)
+  AND bed_number NOT IN (SELECT bed_number FROM target_beds);
+
+INSERT INTO triage_bed_statuses (bed_id, state, last_state_change)
+SELECT b.id, 'empty'::triage_bed_state, COALESCE(b.last_stage_change, CURRENT_TIMESTAMP)
+FROM beds b
+JOIN wards w ON w.id = b.ward_id AND w.code = 'TRIAGE'
+WHERE b.bed_number IN (
+  'TRIAGE-01', 'TRIAGE-02', 'TRIAGE-03',
+  'TRIAGE-04', 'TRIAGE-05', 'TRIAGE-06'
+)
+ON CONFLICT (bed_id) DO NOTHING;
+
+COMMENT ON TABLE triage_bed_statuses IS
+  'Current triage-specific state for each physical triage bed. Independent of ER stages.';
+COMMENT ON TABLE triage_state_logs IS
+  'Immutable audit trail of triage bed state transitions.';

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -525,7 +524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -562,7 +560,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2009,7 +2006,6 @@
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -3593,6 +3589,7 @@
       "version": "5.3.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3690,7 +3687,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3834,7 +3832,6 @@
     "node_modules/@types/node": {
       "version": "20.19.33",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3852,7 +3849,6 @@
       "version": "8.20.0",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -3868,7 +3864,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3877,7 +3872,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3939,7 +3933,6 @@
       "version": "8.56.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4701,7 +4694,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5129,7 +5121,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5643,6 +5634,7 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5681,7 +5673,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.5",
@@ -5989,7 +5982,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6107,7 +6099,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6571,7 +6562,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7466,7 +7456,6 @@
       "version": "28.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -7914,6 +7903,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8486,7 +8476,6 @@
     "node_modules/pg": {
       "version": "8.20.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -8632,7 +8621,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8690,6 +8678,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8703,6 +8692,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8713,7 +8703,8 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8763,7 +8754,6 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8771,7 +8761,6 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8781,13 +8770,11 @@
     },
     "node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8919,8 +8906,7 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9691,8 +9677,7 @@
     "node_modules/tailwindcss": {
       "version": "4.3.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -9772,7 +9757,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10044,7 +10028,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10249,7 +10232,6 @@
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10377,7 +10359,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10389,7 +10370,6 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/app/triage/page.tsx
+++ b/src/app/triage/page.tsx
@@ -1,6 +1,5 @@
 import { verifyActiveSession } from '@/shared/lib/active-session'
-import { BedDashboardContainer } from '@/features/bed-dashboard/components/BedDashboardContainer'
-import { BedGridSkeleton } from '@/features/bed-dashboard/components/BedGridSkeleton'
+import { TriageDashboardContainer } from '@/features/triage/components/TriageDashboardContainer'
 import { LogoutButton } from '@/features/auth/components/LogoutButton'
 import { KioskBanner } from '@/features/auth/components/KioskBanner'
 import { NurseAreaSidebar } from '@/features/bed-dashboard/components/NurseAreaSidebar'
@@ -41,9 +40,9 @@ export default async function TriagePage() {
         <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
           <NurseAreaSidebar activeArea="triage" />
 
-          <div className="min-w-0 flex-1 rounded-xl border border-primary/20 bg-primary/5 p-2 sm:p-3">
-            <Suspense fallback={<BedGridSkeleton />}>
-              <BedDashboardContainer role={session.role} areaView="triage" />
+          <div className="min-w-0 flex-1">
+            <Suspense fallback={<div className="rounded-lg border border-border p-6">Loading triage beds...</div>}>
+              <TriageDashboardContainer />
             </Suspense>
           </div>
         </div>

--- a/src/features/triage/__tests__/actions.test.ts
+++ b/src/features/triage/__tests__/actions.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  assignPatientInDBMock,
+  requireRoleMock,
+  revalidatePathMock,
+  transitionTriageBedInDBMock,
+  updatePatientInDBMock,
+} = vi.hoisted(() => ({
+  assignPatientInDBMock: vi.fn(),
+  requireRoleMock: vi.fn(),
+  revalidatePathMock: vi.fn(),
+  transitionTriageBedInDBMock: vi.fn(),
+  updatePatientInDBMock: vi.fn(),
+}))
+
+vi.mock('@/shared/lib/auth', () => ({
+  requireRole: requireRoleMock,
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: revalidatePathMock,
+}))
+
+vi.mock('../mutations', () => ({
+  assignPatientInDB: assignPatientInDBMock,
+  transitionTriageBedInDB: transitionTriageBedInDBMock,
+  updatePatientInDB: updatePatientInDBMock,
+}))
+
+import {
+  assignTriagePatient,
+  transitionTriageBed,
+  updateTriagePatientDetails,
+} from '../actions'
+
+const BED_ID = '11111111-1111-4111-8111-111111111111'
+
+const patient = {
+  patientUhid: ' UH-1 ',
+  patientIpdId: ' ',
+  patientName: ' Jane Doe ',
+  patientAge: 42,
+  patientGender: 'Female' as const,
+  keySymptom: ' Chest pain ',
+  triageCategory: 'Urgent' as const,
+}
+
+describe('triage actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    requireRoleMock.mockResolvedValue({ userId: 'user-1', role: 'nurse' })
+  })
+
+  it('assigns a patient and normalizes triage details', async () => {
+    assignPatientInDBMock.mockResolvedValue(undefined)
+
+    const result = await assignTriagePatient({ bedId: BED_ID, patient })
+
+    expect(result).toEqual({ success: true })
+    expect(assignPatientInDBMock).toHaveBeenCalledWith(
+      BED_ID,
+      expect.objectContaining({
+        patientUhid: 'UH-1',
+        patientIpdId: null,
+        patientName: 'Jane Doe',
+        keySymptom: 'Chest pain',
+      }),
+      'user-1'
+    )
+    expect(revalidatePathMock).toHaveBeenCalledWith('/triage')
+  })
+
+  it('rejects ER-only target states before mutation code runs', async () => {
+    const result = await transitionTriageBed({ bedId: BED_ID, toState: 'observation' } as never)
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.toState).toBeDefined()
+    expect(transitionTriageBedInDBMock).not.toHaveBeenCalled()
+  })
+
+  it('prevents housekeeping from moving clinical triage states', async () => {
+    requireRoleMock.mockResolvedValue({ userId: 'user-2', role: 'housekeeping' })
+
+    const result = await transitionTriageBed({ bedId: BED_ID, toState: 'decision_made' })
+
+    expect(result).toEqual({ success: false, error: 'Housekeeping can only complete cleaning.' })
+    expect(transitionTriageBedInDBMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces non-triage bed rejection from mutation layer', async () => {
+    transitionTriageBedInDBMock.mockRejectedValue(new Error('Only triage beds can use triage workflow.'))
+
+    const result = await transitionTriageBed({ bedId: BED_ID, toState: 'empty' })
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Only triage beds can use triage workflow.',
+    })
+  })
+
+  it('updates details without changing triage state', async () => {
+    updatePatientInDBMock.mockResolvedValue(undefined)
+
+    const result = await updateTriagePatientDetails({ bedId: BED_ID, patient })
+
+    expect(result).toEqual({ success: true })
+    expect(updatePatientInDBMock).toHaveBeenCalledWith(BED_ID, expect.any(Object), 'user-1')
+  })
+})

--- a/src/features/triage/__tests__/dashboard.test.tsx
+++ b/src/features/triage/__tests__/dashboard.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TriageDashboardClient } from '../components/TriageDashboardClient'
+import type { TriageBed, TriageState } from '../types'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}))
+
+vi.mock('../actions', () => ({
+  assignTriagePatient: vi.fn(),
+  transitionTriageBed: vi.fn(),
+  updateTriagePatientDetails: vi.fn(),
+}))
+
+function makeBed(index: number, state: TriageState = 'empty'): TriageBed {
+  return {
+    id: `00000000-0000-0000-0000-00000000000${index}`,
+    bedNumber: `TRIAGE-0${index}`,
+    state,
+    lastStateChange: new Date('2026-05-21T08:00:00Z'),
+    patientStartTime: null,
+    patient: state === 'empty'
+      ? null
+      : {
+          patientUhid: `UH-${index}`,
+          patientName: `Patient ${index}`,
+          patientAge: 40,
+          patientGender: 'Unknown',
+          keySymptom: 'Chest pain',
+          triageCategory: 'Urgent',
+        },
+  }
+}
+
+describe('TriageDashboardClient', () => {
+  it('renders exactly six triage beds', () => {
+    const beds = Array.from({ length: 6 }, (_, index) => makeBed(index + 1))
+    render(<TriageDashboardClient initialBeds={beds} />)
+
+    expect(screen.getAllByRole('heading', { level: 2 })).toHaveLength(6)
+    expect(screen.getByText('TRIAGE-01')).toBeInTheDocument()
+    expect(screen.getByText('TRIAGE-06')).toBeInTheDocument()
+  })
+
+  it('does not render ER-only stage options', () => {
+    render(<TriageDashboardClient initialBeds={[makeBed(1, 'initial_treatment')]} />)
+
+    expect(screen.queryByText(/Initial Investigation/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Drugs\/Test/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Observation/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Discharge Process/i)).not.toBeInTheDocument()
+  })
+
+  it('renders the correct actions for each state', () => {
+    const beds = [
+      makeBed(1, 'empty'),
+      makeBed(2, 'initial_treatment'),
+      makeBed(3, 'decision_made'),
+      makeBed(4, 'cleaning'),
+    ]
+    render(<TriageDashboardClient initialBeds={beds} />)
+
+    expect(screen.getByText('Assign Patient')).toBeInTheDocument()
+    expect(screen.getByText('Mark Decision Made')).toBeInTheDocument()
+    expect(screen.getByText('Move to Cleaning')).toBeInTheDocument()
+    expect(screen.getByText('Cleaning Complete')).toBeInTheDocument()
+  })
+})

--- a/src/features/triage/__tests__/mutations.test.ts
+++ b/src/features/triage/__tests__/mutations.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { connectMock, queryMock, releaseMock } = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  queryMock: vi.fn(),
+  releaseMock: vi.fn(),
+}))
+
+vi.mock('@/shared/lib/db', () => ({
+  __esModule: true,
+  default: { connect: connectMock },
+}))
+
+vi.mock('@/shared/config/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+import {
+  assignPatientInDB,
+  transitionTriageBedInDB,
+} from '../mutations'
+
+const BED_ID = '11111111-1111-4111-8111-111111111111'
+const USER_ID = '22222222-2222-4222-8222-222222222222'
+
+const patient = {
+  patientUhid: 'UH-1',
+  patientIpdId: null,
+  patientName: 'Jane Doe',
+  patientAge: 42,
+  patientGender: 'Female' as const,
+  keySymptom: 'Chest pain',
+  triageCategory: 'Urgent' as const,
+}
+
+function setupClient() {
+  queryMock.mockReset()
+  releaseMock.mockReset()
+  connectMock.mockResolvedValue({ query: queryMock, release: releaseMock })
+}
+
+function mockLockedBed(state = 'empty', wardCode = 'TRIAGE') {
+  queryMock
+    .mockResolvedValueOnce({ rows: [], rowCount: null })
+    .mockResolvedValueOnce({ rows: [{ id: BED_ID, bedNumber: 'TRIAGE-01', wardCode }] })
+    .mockResolvedValueOnce({
+      rows: [{ state, lastStateChange: new Date('2026-05-21T08:00:00Z') }],
+    })
+}
+
+describe('triage mutations', () => {
+  beforeEach(() => setupClient())
+
+  it('assignment writes patient data, state log, and audit log in one transaction', async () => {
+    mockLockedBed('empty')
+    queryMock.mockResolvedValue({ rows: [], rowCount: null })
+
+    await assignPatientInDB(BED_ID, patient, USER_ID)
+
+    const sql = queryMock.mock.calls.map((call) => String(call[0]))
+    expect(sql[0]).toBe('BEGIN')
+    expect(sql.some((text) => text.includes('UPDATE beds'))).toBe(true)
+    expect(sql.some((text) => text.includes('UPDATE triage_bed_statuses'))).toBe(true)
+    expect(sql.some((text) => text.includes('INSERT INTO triage_state_logs'))).toBe(true)
+    expect(sql.some((text) => text.includes('INSERT INTO audit_logs'))).toBe(true)
+    expect(sql.at(-1)).toBe('COMMIT')
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects non-triage beds before state changes are written', async () => {
+    mockLockedBed('empty', 'ER')
+
+    await expect(transitionTriageBedInDB(BED_ID, 'cleaning', USER_ID)).rejects.toThrow(
+      'Only triage beds can use triage workflow.'
+    )
+
+    const sql = queryMock.mock.calls.map((call) => String(call[0]))
+    expect(sql.some((text) => text.includes('INSERT INTO triage_state_logs'))).toBe(false)
+    expect(sql).toContain('ROLLBACK')
+  })
+
+  it('rejects invalid triage transitions without audit writes', async () => {
+    mockLockedBed('decision_made')
+
+    await expect(transitionTriageBedInDB(BED_ID, 'initial_treatment', USER_ID)).rejects.toThrow(
+      'Cannot move triage bed'
+    )
+
+    const sql = queryMock.mock.calls.map((call) => String(call[0]))
+    expect(sql.some((text) => text.includes('INSERT INTO audit_logs'))).toBe(false)
+    expect(sql).toContain('ROLLBACK')
+  })
+})

--- a/src/features/triage/__tests__/state.test.ts
+++ b/src/features/triage/__tests__/state.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TRIAGE_STATES,
+  type TriageState,
+} from '../types'
+import {
+  getAllowedTriageTransitions,
+  isErOnlyStateName,
+  validateTriageTransition,
+} from '../state'
+
+describe('triage state model', () => {
+  it('exposes only the four approved triage states', () => {
+    expect(TRIAGE_STATES).toEqual([
+      'empty',
+      'initial_treatment',
+      'decision_made',
+      'cleaning',
+    ])
+  })
+
+  it('allows only the approved triage transition path', () => {
+    const validPairs: Array<[TriageState, TriageState]> = [
+      ['empty', 'initial_treatment'],
+      ['initial_treatment', 'decision_made'],
+      ['decision_made', 'cleaning'],
+      ['cleaning', 'empty'],
+    ]
+
+    for (const [fromState, toState] of validPairs) {
+      expect(validateTriageTransition(fromState, toState)).toEqual({ success: true })
+    }
+  })
+
+  it('rejects invalid skips and reverse moves', () => {
+    expect(validateTriageTransition('empty', 'decision_made').success).toBe(false)
+    expect(validateTriageTransition('decision_made', 'initial_treatment').success).toBe(false)
+    expect(validateTriageTransition('initial_treatment', 'cleaning').success).toBe(false)
+  })
+
+  it('keeps assignment and cleaning completion tied to their source states', () => {
+    expect(getAllowedTriageTransitions('empty')).toEqual(['initial_treatment'])
+    expect(getAllowedTriageTransitions('cleaning')).toEqual(['empty'])
+  })
+
+  it('identifies ER-only state names as forbidden in triage', () => {
+    expect(isErOnlyStateName('Initial Investigation')).toBe(true)
+    expect(isErOnlyStateName('Drugs/Test')).toBe(true)
+    expect(isErOnlyStateName('Observation')).toBe(true)
+    expect(isErOnlyStateName('Discharge Process')).toBe(true)
+  })
+})

--- a/src/features/triage/actions.ts
+++ b/src/features/triage/actions.ts
@@ -1,0 +1,85 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { requireRole } from '@/shared/lib/auth'
+import {
+  assignTriagePatientSchema,
+  normalizePatientDetails,
+  transitionTriageBedSchema,
+  updateTriageDetailsSchema,
+  type AssignTriagePatientInput,
+  type TransitionTriageBedInput,
+  type UpdateTriageDetailsInput,
+} from './schemas'
+import {
+  assignPatientInDB,
+  transitionTriageBedInDB,
+  updatePatientInDB,
+} from './mutations'
+
+type ActionResult = { success: boolean; error?: string; errors?: Record<string, string[]> }
+
+function flattenErrors(error: { flatten: () => { fieldErrors: Record<string, string[]> } }) {
+  return error.flatten().fieldErrors
+}
+
+function canPerformClinicalAction(role: string) {
+  return role === 'nurse' || role === 'supervisor' || role === 'admin'
+}
+
+export async function assignTriagePatient(input: AssignTriagePatientInput): Promise<ActionResult> {
+  try {
+    const session = await requireRole(['nurse', 'supervisor', 'admin'])
+    const parsed = assignTriagePatientSchema.safeParse(input)
+    if (!parsed.success) return { success: false, errors: flattenErrors(parsed.error) }
+
+    await assignPatientInDB(
+      parsed.data.bedId,
+      normalizePatientDetails(parsed.data.patient),
+      session.userId
+    )
+    revalidatePath('/triage')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Assignment failed' }
+  }
+}
+
+export async function updateTriagePatientDetails(
+  input: UpdateTriageDetailsInput
+): Promise<ActionResult> {
+  try {
+    const session = await requireRole(['nurse', 'supervisor', 'admin'])
+    const parsed = updateTriageDetailsSchema.safeParse(input)
+    if (!parsed.success) return { success: false, errors: flattenErrors(parsed.error) }
+
+    await updatePatientInDB(
+      parsed.data.bedId,
+      normalizePatientDetails(parsed.data.patient),
+      session.userId
+    )
+    revalidatePath('/triage')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Update failed' }
+  }
+}
+
+export async function transitionTriageBed(input: TransitionTriageBedInput): Promise<ActionResult> {
+  try {
+    const session = await requireRole(['nurse', 'housekeeping', 'supervisor', 'admin'])
+    const parsed = transitionTriageBedSchema.safeParse(input)
+    if (!parsed.success) return { success: false, errors: flattenErrors(parsed.error) }
+
+    const isCleaningComplete = parsed.data.toState === 'empty'
+    if (!canPerformClinicalAction(session.role) && !isCleaningComplete) {
+      return { success: false, error: 'Housekeeping can only complete cleaning.' }
+    }
+
+    await transitionTriageBedInDB(parsed.data.bedId, parsed.data.toState, session.userId)
+    revalidatePath('/triage')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'State update failed' }
+  }
+}

--- a/src/features/triage/components/TriageBedCard.tsx
+++ b/src/features/triage/components/TriageBedCard.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CheckCircle2, ClipboardEdit, Clock3, Eraser, UserPlus } from 'lucide-react'
+import { Badge } from '@/shared/components/ui/badge'
+import { Button } from '@/shared/components/ui/button'
+import { Card, CardContent } from '@/shared/components/ui/card'
+import { TRIAGE_STATE_LABELS, TRIAGE_STATE_STYLES, type TriageBed } from '../types'
+
+interface TriageBedCardProps {
+  bed: TriageBed
+  isPending: boolean
+  onAssign: (bed: TriageBed) => void
+  onEdit: (bed: TriageBed) => void
+  onTransition: (bed: TriageBed) => void
+}
+
+function formatElapsed(from: Date, now: Date) {
+  const ms = Math.max(0, now.getTime() - new Date(from).getTime())
+  const totalMinutes = Math.floor(ms / 60000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
+}
+
+export function TriageBedCard({
+  bed,
+  isPending,
+  onAssign,
+  onEdit,
+  onTransition,
+}: TriageBedCardProps) {
+  const [now, setNow] = useState(() => new Date())
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(new Date()), 60000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  const patientName = bed.patient?.patientName || 'No patient assigned'
+  const complaint = bed.patient?.keySymptom || 'No complaint recorded'
+  const category = bed.patient?.triageCategory
+  const styles = TRIAGE_STATE_STYLES[bed.state]
+
+  return (
+    <Card className={`relative overflow-hidden rounded-lg border-2 bg-card text-card-foreground shadow-sm ${styles.border}`}>
+      <div className={`absolute inset-y-0 left-0 w-1.5 ${styles.accent}`} aria-hidden="true" />
+      <CardContent className="p-4 pl-5 space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-bold tracking-tight text-foreground">{bed.bedNumber}</h2>
+            <div className="mt-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+              <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+              <span>In state {formatElapsed(bed.lastStateChange, now)}</span>
+            </div>
+          </div>
+          <Badge variant="outline" className={styles.badge}>
+            {TRIAGE_STATE_LABELS[bed.state]}
+          </Badge>
+        </div>
+
+        <div className="min-h-28 rounded-md border border-border bg-background/80 p-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-foreground">{patientName}</p>
+              {bed.patient?.patientUhid && (
+                <p className="text-xs font-medium text-muted-foreground">UHID {bed.patient.patientUhid}</p>
+              )}
+            </div>
+            {category && <Badge variant="secondary" className="shrink-0">{category}</Badge>}
+          </div>
+          <p className="mt-3 line-clamp-2 text-sm text-foreground/80">{complaint}</p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {bed.state === 'empty' && (
+            <Button className="sm:col-span-2" size="sm" onClick={() => onAssign(bed)} disabled={isPending}>
+              <UserPlus className="h-4 w-4" /> Assign Patient
+            </Button>
+          )}
+          {(bed.state === 'initial_treatment' || bed.state === 'decision_made') && (
+            <Button size="sm" variant="outline" onClick={() => onEdit(bed)} disabled={isPending}>
+              <ClipboardEdit className="h-4 w-4" /> Edit Details
+            </Button>
+          )}
+          {bed.state === 'initial_treatment' && (
+            <Button size="sm" onClick={() => onTransition(bed)} disabled={isPending}>
+              <CheckCircle2 className="h-4 w-4" /> Mark Decision Made
+            </Button>
+          )}
+          {bed.state === 'decision_made' && (
+            <Button size="sm" onClick={() => onTransition(bed)} disabled={isPending}>
+              <Eraser className="h-4 w-4" /> Move to Cleaning
+            </Button>
+          )}
+          {bed.state === 'cleaning' && (
+            <Button className="sm:col-span-2" size="sm" onClick={() => onTransition(bed)} disabled={isPending}>
+              <CheckCircle2 className="h-4 w-4" /> Cleaning Complete
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/triage/components/TriageDashboardClient.tsx
+++ b/src/features/triage/components/TriageDashboardClient.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useEffect, useMemo, useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { assignTriagePatient, transitionTriageBed, updateTriagePatientDetails } from '../actions'
+import {
+  TRIAGE_STATE_LABELS,
+  type TriageBed,
+  type TriagePatientDetails,
+  type TriageState,
+} from '../types'
+import { TriageBedCard } from './TriageBedCard'
+import { TriagePatientModal } from './TriagePatientModal'
+
+interface TriageDashboardClientProps {
+  initialBeds: TriageBed[]
+}
+
+type ModalState = { bed: TriageBed; mode: 'assign' | 'edit' } | null
+
+const NEXT_STATE: Partial<Record<TriageState, TriageState>> = {
+  initial_treatment: 'decision_made',
+  decision_made: 'cleaning',
+  cleaning: 'empty',
+}
+
+function nextActionState(bed: TriageBed) {
+  return NEXT_STATE[bed.state]
+}
+
+export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProps) {
+  const router = useRouter()
+  const [beds, setBeds] = useState(initialBeds)
+  const [modalState, setModalState] = useState<ModalState>(null)
+  const [pendingBedId, setPendingBedId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => setBeds(initialBeds), [initialBeds])
+
+  const counts = useMemo(() => ({
+    total: beds.length,
+    occupied: beds.filter((bed) => bed.state === 'initial_treatment' || bed.state === 'decision_made').length,
+    cleaning: beds.filter((bed) => bed.state === 'cleaning').length,
+    empty: beds.filter((bed) => bed.state === 'empty').length,
+  }), [beds])
+
+  const refreshAfterSuccess = () => {
+    setError(null)
+    setModalState(null)
+    router.refresh()
+  }
+
+  const handlePatientSubmit = (bedId: string, patient: TriagePatientDetails) => {
+    const mode = modalState?.mode
+    setPendingBedId(bedId)
+    startTransition(async () => {
+      const result = mode === 'assign'
+        ? await assignTriagePatient({ bedId, patient })
+        : await updateTriagePatientDetails({ bedId, patient })
+      setPendingBedId(null)
+      if (!result.success) {
+        setError(result.error || 'Please check the triage details.')
+        return
+      }
+      refreshAfterSuccess()
+    })
+  }
+
+  const handleTransition = (bed: TriageBed) => {
+    const toState = nextActionState(bed)
+    if (!toState) return
+    setPendingBedId(bed.id)
+    startTransition(async () => {
+      const result = await transitionTriageBed({ bedId: bed.id, toState })
+      setPendingBedId(null)
+      if (!result.success) {
+        setError(result.error || `Could not move bed to ${TRIAGE_STATE_LABELS[toState]}.`)
+        return
+      }
+      refreshAfterSuccess()
+    })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Summary label="Total" value={counts.total} />
+        <Summary label="Occupied" value={counts.occupied} />
+        <Summary label="Cleaning" value={counts.cleaning} />
+        <Summary label="Empty" value={counts.empty} />
+      </div>
+
+      {error && !modalState && (
+        <div className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {beds.map((bed) => (
+          <TriageBedCard
+            key={bed.id}
+            bed={bed}
+            isPending={(isPending && pendingBedId === bed.id) || Boolean(pendingBedId)}
+            onAssign={(nextBed) => { setError(null); setModalState({ bed: nextBed, mode: 'assign' }) }}
+            onEdit={(nextBed) => { setError(null); setModalState({ bed: nextBed, mode: 'edit' }) }}
+            onTransition={handleTransition}
+          />
+        ))}
+      </div>
+
+      <TriagePatientModal
+        bed={modalState?.bed ?? null}
+        mode={modalState?.mode ?? 'assign'}
+        isOpen={Boolean(modalState)}
+        isSubmitting={isPending}
+        error={modalState ? error : null}
+        onClose={() => { setError(null); setModalState(null) }}
+        onSubmit={handlePatientSubmit}
+      />
+    </div>
+  )
+}
+
+function Summary({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-border bg-card px-4 py-3">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold">{value}</p>
+    </div>
+  )
+}

--- a/src/features/triage/components/TriageDashboardContainer.tsx
+++ b/src/features/triage/components/TriageDashboardContainer.tsx
@@ -1,0 +1,19 @@
+import { AlertTriangle } from 'lucide-react'
+import { getTriageDashboardData } from '../queries'
+import { TriageDashboardClient } from './TriageDashboardClient'
+
+export async function TriageDashboardContainer() {
+  const result = await getTriageDashboardData()
+
+  if (!result.success || !result.data) {
+    return (
+      <div className="rounded-lg border border-destructive bg-destructive/20 p-8 text-center">
+        <AlertTriangle className="h-12 w-12 text-destructive mx-auto mb-4" />
+        <p className="text-destructive font-semibold mb-2">Failed to load triage beds</p>
+        <p className="text-muted-foreground text-sm">{result.error}</p>
+      </div>
+    )
+  }
+
+  return <TriageDashboardClient initialBeds={result.data.beds} />
+}

--- a/src/features/triage/components/TriagePatientForm.tsx
+++ b/src/features/triage/components/TriagePatientForm.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { Input } from '@/shared/components/ui/input'
+import { Label } from '@/shared/components/ui/label'
+import { Textarea } from '@/shared/components/ui/textarea'
+import {
+  TRIAGE_CATEGORY_OPTIONS,
+  type PatientGender,
+  type TriageCategory,
+  type TriagePatientDetails,
+} from '../types'
+import { SYMPTOM_MAX_LENGTH } from '../schemas'
+
+interface TriagePatientFormProps {
+  value: TriagePatientDetails
+  disabled: boolean
+  onChange: (value: TriagePatientDetails) => void
+}
+
+function updateValue<K extends keyof TriagePatientDetails>(
+  value: TriagePatientDetails,
+  key: K,
+  next: TriagePatientDetails[K],
+) {
+  return { ...value, [key]: next }
+}
+
+export function TriagePatientForm({ value, disabled, onChange }: TriagePatientFormProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="triageCategory">Triage Category</Label>
+        <select
+          id="triageCategory"
+          value={value.triageCategory}
+          disabled={disabled}
+          onChange={(event) => onChange(updateValue(value, 'triageCategory', event.target.value as TriageCategory))}
+          className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        >
+          {TRIAGE_CATEGORY_OPTIONS.map((category) => (
+            <option key={category} value={category}>{category}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="patientUhid">Patient UHID</Label>
+          <Input
+            id="patientUhid"
+            value={value.patientUhid}
+            disabled={disabled}
+            onChange={(event) => onChange(updateValue(value, 'patientUhid', event.target.value))}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="patientIpdId">IPD ID</Label>
+          <Input
+            id="patientIpdId"
+            value={value.patientIpdId ?? ''}
+            disabled={disabled}
+            onChange={(event) => onChange(updateValue(value, 'patientIpdId', event.target.value))}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="patientName">Patient Name</Label>
+        <Input
+          id="patientName"
+          value={value.patientName}
+          disabled={disabled}
+          onChange={(event) => onChange(updateValue(value, 'patientName', event.target.value))}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="patientAge">Age</Label>
+          <Input
+            id="patientAge"
+            type="number"
+            min={1}
+            max={130}
+            value={value.patientAge || ''}
+            disabled={disabled}
+            onChange={(event) => {
+              onChange(updateValue(value, 'patientAge', Number(event.target.value)))
+            }}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="patientGender">Gender</Label>
+          <select
+            id="patientGender"
+            value={value.patientGender}
+            disabled={disabled}
+            onChange={(event) => onChange(updateValue(value, 'patientGender', event.target.value as PatientGender))}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+          >
+            <option value="Male">Male</option>
+            <option value="Female">Female</option>
+            <option value="Other">Other</option>
+            <option value="Unknown">Unknown</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="keySymptom">Symptoms / Complaint</Label>
+        <Textarea
+          id="keySymptom"
+          value={value.keySymptom}
+          maxLength={SYMPTOM_MAX_LENGTH}
+          disabled={disabled}
+          onChange={(event) => {
+            onChange(updateValue(value, 'keySymptom', event.target.value.slice(0, SYMPTOM_MAX_LENGTH)))
+          }}
+        />
+        <p className="text-[10px] text-muted-foreground">{value.keySymptom.length}/{SYMPTOM_MAX_LENGTH}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/features/triage/components/TriagePatientModal.tsx
+++ b/src/features/triage/components/TriagePatientModal.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import { Button } from '@/shared/components/ui/button'
+import { type TriageBed, type TriagePatientDetails } from '../types'
+import { TriagePatientForm } from './TriagePatientForm'
+
+interface TriagePatientModalProps {
+  bed: TriageBed | null
+  mode: 'assign' | 'edit'
+  isOpen: boolean
+  isSubmitting: boolean
+  error: string | null
+  onClose: () => void
+  onSubmit: (bedId: string, details: TriagePatientDetails) => void
+}
+
+const EMPTY_PATIENT: TriagePatientDetails = {
+  patientUhid: '',
+  patientIpdId: '',
+  patientName: '',
+  patientAge: 0,
+  patientGender: 'Unknown',
+  keySymptom: '',
+  triageCategory: 'Urgent',
+}
+
+function detailsFromBed(bed: TriageBed | null): TriagePatientDetails {
+  if (!bed?.patient) return EMPTY_PATIENT
+  return {
+    patientUhid: bed.patient.patientUhid ?? '',
+    patientIpdId: bed.patient.patientIpdId ?? '',
+    patientName: bed.patient.patientName ?? '',
+    patientAge: bed.patient.patientAge ?? 0,
+    patientGender: bed.patient.patientGender ?? 'Unknown',
+    keySymptom: bed.patient.keySymptom ?? '',
+    triageCategory: bed.patient.triageCategory ?? 'Urgent',
+  }
+}
+
+export function TriagePatientModal({
+  bed,
+  mode,
+  isOpen,
+  isSubmitting,
+  error,
+  onClose,
+  onSubmit,
+}: TriagePatientModalProps) {
+  const [details, setDetails] = useState<TriagePatientDetails>(EMPTY_PATIENT)
+
+  useEffect(() => {
+    if (isOpen) setDetails(detailsFromBed(bed))
+  }, [bed, isOpen])
+
+  if (!isOpen || !bed) return null
+
+  const title = mode === 'assign' ? `Assign ${bed.bedNumber}` : `Edit ${bed.bedNumber}`
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="triage-patient-title"
+    >
+      <div className="w-full max-w-2xl rounded-lg border border-border bg-background shadow-xl">
+        <div className="flex items-center justify-between border-b border-border p-4">
+          <div>
+            <h2 id="triage-patient-title" className="text-lg font-semibold">{title}</h2>
+            <p className="text-sm text-muted-foreground">Triage details stay inside the triage area workflow.</p>
+          </div>
+          <Button type="button" variant="ghost" size="icon" onClick={onClose} disabled={isSubmitting}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <form
+          className="space-y-4 p-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            onSubmit(bed.id, details)
+          }}
+        >
+          <TriagePatientForm value={details} disabled={isSubmitting} onChange={setDetails} />
+          {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+
+          <div className="flex justify-end gap-2 border-t border-border pt-4">
+            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isSubmitting}>
+              {mode === 'assign' ? 'Assign Patient' : 'Save Details'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/features/triage/mutations.ts
+++ b/src/features/triage/mutations.ts
@@ -3,53 +3,7 @@ import { logger } from '@/shared/config/logger'
 import type { PoolClient } from 'pg'
 import type { TriagePatientDetails, TriageState } from './types'
 import { validateTriageTransition } from './state'
-
-type LockedTriageBed = {
-  id: string
-  bedNumber: string
-  state: TriageState
-  lastStateChange: Date
-}
-
-async function lockTriageBed(client: PoolClient, bedId: string): Promise<LockedTriageBed> {
-  const bedResult = await client.query<{ id: string; bedNumber: string; wardCode: string }>(
-    `
-    SELECT b.id, b.bed_number as "bedNumber", w.code as "wardCode"
-    FROM beds b
-    JOIN wards w ON w.id = b.ward_id
-    WHERE b.id = $1 AND b.is_active = true
-    FOR UPDATE OF b
-    `,
-    [bedId]
-  )
-
-  const bed = bedResult.rows[0]
-  if (!bed) throw new Error('Bed not found.')
-  if (bed.wardCode !== 'TRIAGE') throw new Error('Only triage beds can use triage workflow.')
-
-  const statusResult = await client.query<{
-    state: TriageState
-    lastStateChange: Date
-  }>(
-    `SELECT state, last_state_change as "lastStateChange"
-     FROM triage_bed_statuses
-     WHERE bed_id = $1
-     FOR UPDATE`,
-    [bedId]
-  )
-
-  if (statusResult.rows[0]) {
-    return { id: bed.id, bedNumber: bed.bedNumber, ...statusResult.rows[0] }
-  }
-
-  const inserted = await client.query<{ state: TriageState; lastStateChange: Date }>(
-    `INSERT INTO triage_bed_statuses (bed_id, state)
-     VALUES ($1, 'empty')
-     RETURNING state, last_state_change as "lastStateChange"`,
-    [bedId]
-  )
-  return { id: bed.id, bedNumber: bed.bedNumber, ...inserted.rows[0] }
-}
+import { lockTriageBed, type LockedTriageBed } from './triage-bed-lock'
 
 function durationFrom(startedAt: Date): number {
   return Date.now() - new Date(startedAt).getTime()

--- a/src/features/triage/mutations.ts
+++ b/src/features/triage/mutations.ts
@@ -1,0 +1,204 @@
+import pool from '@/shared/lib/db'
+import { logger } from '@/shared/config/logger'
+import type { PoolClient } from 'pg'
+import type { TriagePatientDetails, TriageState } from './types'
+import { validateTriageTransition } from './state'
+
+type LockedTriageBed = {
+  id: string
+  bedNumber: string
+  state: TriageState
+  lastStateChange: Date
+}
+
+async function lockTriageBed(client: PoolClient, bedId: string): Promise<LockedTriageBed> {
+  const bedResult = await client.query<{ id: string; bedNumber: string; wardCode: string }>(
+    `
+    SELECT b.id, b.bed_number as "bedNumber", w.code as "wardCode"
+    FROM beds b
+    JOIN wards w ON w.id = b.ward_id
+    WHERE b.id = $1 AND b.is_active = true
+    FOR UPDATE OF b
+    `,
+    [bedId]
+  )
+
+  const bed = bedResult.rows[0]
+  if (!bed) throw new Error('Bed not found.')
+  if (bed.wardCode !== 'TRIAGE') throw new Error('Only triage beds can use triage workflow.')
+
+  const statusResult = await client.query<{
+    state: TriageState
+    lastStateChange: Date
+  }>(
+    `SELECT state, last_state_change as "lastStateChange"
+     FROM triage_bed_statuses
+     WHERE bed_id = $1
+     FOR UPDATE`,
+    [bedId]
+  )
+
+  if (statusResult.rows[0]) {
+    return { id: bed.id, bedNumber: bed.bedNumber, ...statusResult.rows[0] }
+  }
+
+  const inserted = await client.query<{ state: TriageState; lastStateChange: Date }>(
+    `INSERT INTO triage_bed_statuses (bed_id, state)
+     VALUES ($1, 'empty')
+     RETURNING state, last_state_change as "lastStateChange"`,
+    [bedId]
+  )
+  return { id: bed.id, bedNumber: bed.bedNumber, ...inserted.rows[0] }
+}
+
+function durationFrom(startedAt: Date): number {
+  return Date.now() - new Date(startedAt).getTime()
+}
+
+async function writeTriageLog(
+  client: PoolClient,
+  bed: LockedTriageBed,
+  toState: TriageState,
+  userId: string,
+  metadata: Record<string, unknown>,
+  notes?: string
+) {
+  await client.query(
+    `INSERT INTO triage_state_logs (
+       bed_id, from_state, to_state, changed_by_user_id,
+       duration_in_previous_state_ms, notes, metadata
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+    [bed.id, bed.state, toState, userId, durationFrom(bed.lastStateChange), notes ?? null, JSON.stringify(metadata)]
+  )
+}
+
+async function writeAudit(
+  client: PoolClient,
+  bed: LockedTriageBed,
+  toState: TriageState,
+  userId: string,
+  metadata: Record<string, unknown>
+) {
+  await client.query(
+    `INSERT INTO audit_logs (
+       action_type, entity_type, entity_id, performed_by_user_id,
+       changes, reason, metadata
+     ) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7::jsonb)`,
+    [
+      'UPDATE',
+      'triage_bed',
+      bed.id,
+      userId,
+      JSON.stringify({ fromState: bed.state, toState }),
+      'Triage bed state updated',
+      JSON.stringify({ ...metadata, bedNumber: bed.bedNumber }),
+    ]
+  )
+}
+
+async function setTriageState(client: PoolClient, bedId: string, toState: TriageState) {
+  await client.query(
+    `UPDATE triage_bed_statuses
+     SET state = $1, last_state_change = NOW(), updated_at = NOW()
+     WHERE bed_id = $2`,
+    [toState, bedId]
+  )
+}
+
+async function savePatient(client: PoolClient, bedId: string, patient: TriagePatientDetails) {
+  await client.query(
+    `UPDATE beds
+     SET patient_uhid = $1, patient_ipd_id = $2, patient_name = $3,
+         patient_age = $4, patient_gender = $5, key_symptom = $6,
+         triage_category = $7, patient_start_time = COALESCE(patient_start_time, NOW()),
+         is_occupied = true,
+         metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{triageInfo}', $8::jsonb, true),
+         updated_at = NOW()
+     WHERE id = $9`,
+    [
+      patient.patientUhid,
+      patient.patientIpdId,
+      patient.patientName,
+      patient.patientAge,
+      patient.patientGender,
+      patient.keySymptom || null,
+      patient.triageCategory,
+      JSON.stringify(patient),
+      bedId,
+    ]
+  )
+}
+
+async function clearPatient(client: PoolClient, bedId: string) {
+  await client.query(
+    `UPDATE beds
+     SET patient_uhid = NULL, patient_ipd_id = NULL, patient_name = NULL,
+         patient_age = NULL, patient_gender = NULL, key_symptom = NULL,
+         triage_category = NULL, patient_start_time = NULL, is_occupied = false,
+         metadata = COALESCE(metadata, '{}'::jsonb) - 'triageInfo',
+         updated_at = NOW()
+     WHERE id = $1`,
+    [bedId]
+  )
+}
+
+export async function assignPatientInDB(bedId: string, patient: TriagePatientDetails, userId: string) {
+  const metadata = { source: 'triage', assignment: true, triageCategory: patient.triageCategory }
+  return runTriageMutation(bedId, 'initial_treatment', userId, metadata, async (client) => {
+    await savePatient(client, bedId, patient)
+  })
+}
+
+export async function updatePatientInDB(bedId: string, patient: TriagePatientDetails, userId: string) {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    const bed = await lockTriageBed(client, bedId)
+    if (bed.state !== 'initial_treatment' && bed.state !== 'decision_made') {
+      throw new Error('Triage details can only be edited while treatment or decision is active.')
+    }
+    await savePatient(client, bedId, patient)
+    await writeAudit(client, bed, bed.state, userId, { source: 'triage', patientUpdated: true })
+    await client.query('COMMIT')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    logger.error('Failed to update triage patient details', error as Error, { bedId })
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+export async function transitionTriageBedInDB(bedId: string, toState: TriageState, userId: string) {
+  return runTriageMutation(bedId, toState, userId, { source: 'triage' }, async (client) => {
+    if (toState === 'cleaning') await clearPatient(client, bedId)
+    if (toState === 'empty') await clearPatient(client, bedId)
+  })
+}
+
+async function runTriageMutation(
+  bedId: string,
+  toState: TriageState,
+  userId: string,
+  metadata: Record<string, unknown>,
+  beforeStateWrite: (client: PoolClient, bed: LockedTriageBed) => Promise<void>
+) {
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
+    const bed = await lockTriageBed(client, bedId)
+    const validation = validateTriageTransition(bed.state, toState)
+    if (validation.success === false) throw new Error(validation.error)
+    await beforeStateWrite(client, bed)
+    await setTriageState(client, bedId, toState)
+    await writeTriageLog(client, bed, toState, userId, metadata)
+    await writeAudit(client, bed, toState, userId, metadata)
+    await client.query('COMMIT')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    logger.error('Failed to mutate triage bed', error as Error, { bedId, toState })
+    throw error
+  } finally {
+    client.release()
+  }
+}

--- a/src/features/triage/queries.ts
+++ b/src/features/triage/queries.ts
@@ -1,0 +1,92 @@
+import { query } from '@/shared/lib/db'
+import { logger } from '@/shared/config/logger'
+import { requireRole } from '@/shared/lib/auth'
+import {
+  TRIAGE_BED_NUMBERS,
+  type TriageBed,
+  type TriageCategory,
+  type TriageState,
+} from './types'
+
+type TriageBedRow = {
+  id: string
+  bedNumber: string
+  state: TriageState
+  lastStateChange: Date
+  patientStartTime: Date | null
+  patientUhid: string | null
+  patientIpdId: string | null
+  patientName: string | null
+  patientAge: number | null
+  patientGender: 'Male' | 'Female' | 'Other' | 'Unknown' | null
+  keySymptom: string | null
+  triageCategory: TriageCategory | null
+}
+
+function toTriageBed(row: TriageBedRow): TriageBed {
+  const hasPatient = Boolean(row.patientUhid || row.patientName || row.triageCategory)
+
+  return {
+    id: row.id,
+    bedNumber: row.bedNumber,
+    state: row.state,
+    lastStateChange: row.lastStateChange,
+    patientStartTime: row.patientStartTime,
+    patient: hasPatient
+      ? {
+          patientUhid: row.patientUhid ?? undefined,
+          patientIpdId: row.patientIpdId,
+          patientName: row.patientName ?? undefined,
+          patientAge: row.patientAge ?? undefined,
+          patientGender: row.patientGender ?? undefined,
+          keySymptom: row.keySymptom ?? '',
+          triageCategory: row.triageCategory ?? undefined,
+        }
+      : null,
+  }
+}
+
+export async function getTriageDashboardData(): Promise<{
+  success: boolean
+  data?: { beds: TriageBed[] }
+  error?: string
+}> {
+  try {
+    await requireRole(['nurse', 'housekeeping', 'supervisor', 'admin'])
+
+    const result = await query<TriageBedRow>(
+      `
+      WITH target_beds(bed_number, sort_order) AS (
+        SELECT * FROM unnest($1::text[]) WITH ORDINALITY
+      )
+      SELECT
+        b.id,
+        b.bed_number as "bedNumber",
+        COALESCE(tbs.state, 'empty'::triage_bed_state) as "state",
+        COALESCE(tbs.last_state_change, b.last_stage_change, b.created_at) as "lastStateChange",
+        b.patient_start_time as "patientStartTime",
+        b.patient_uhid as "patientUhid",
+        b.patient_ipd_id as "patientIpdId",
+        b.patient_name as "patientName",
+        b.patient_age as "patientAge",
+        b.patient_gender as "patientGender",
+        b.key_symptom as "keySymptom",
+        b.triage_category as "triageCategory"
+      FROM target_beds tb
+      JOIN beds b ON b.bed_number = tb.bed_number AND b.is_active = true
+      JOIN wards w ON w.id = b.ward_id AND w.code = 'TRIAGE'
+      LEFT JOIN triage_bed_statuses tbs ON tbs.bed_id = b.id
+      ORDER BY tb.sort_order
+      `,
+      [TRIAGE_BED_NUMBERS]
+    )
+
+    return { success: true, data: { beds: result.rows.map(toTriageBed) } }
+  } catch (error) {
+    logger.error('Failed to fetch triage dashboard data', error as Error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to load triage beds',
+    }
+  }
+}

--- a/src/features/triage/schemas.ts
+++ b/src/features/triage/schemas.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod'
+import {
+  TRIAGE_CATEGORY_OPTIONS,
+  TRIAGE_STATES,
+  type TriagePatientDetails,
+  type TriageState,
+} from './types'
+
+export const SYMPTOM_MAX_LENGTH = 40
+
+const patientDetailsSchema = z.object({
+  patientUhid: z.string().trim().min(1, 'UHID is required').max(100),
+  patientIpdId: z.string().trim().max(100).optional().nullable(),
+  patientName: z.string().trim().min(1, 'Patient name is required').max(255),
+  patientAge: z.number().int().min(1).max(130),
+  patientGender: z.enum(['Male', 'Female', 'Other', 'Unknown']),
+  keySymptom: z.string().trim().max(SYMPTOM_MAX_LENGTH).default(''),
+  triageCategory: z.enum(TRIAGE_CATEGORY_OPTIONS),
+})
+
+export const assignTriagePatientSchema = z.object({
+  bedId: z.string().uuid('Invalid bed ID'),
+  patient: patientDetailsSchema,
+})
+
+export const updateTriageDetailsSchema = assignTriagePatientSchema
+
+export const transitionTriageBedSchema = z.object({
+  bedId: z.string().uuid('Invalid bed ID'),
+  toState: z.enum(TRIAGE_STATES),
+})
+
+export type AssignTriagePatientInput = z.infer<typeof assignTriagePatientSchema>
+export type UpdateTriageDetailsInput = z.infer<typeof updateTriageDetailsSchema>
+export type TransitionTriageBedInput = z.infer<typeof transitionTriageBedSchema>
+
+export function normalizePatientDetails(patient: TriagePatientDetails): TriagePatientDetails {
+  return {
+    patientUhid: patient.patientUhid.trim(),
+    patientIpdId: patient.patientIpdId?.trim() || null,
+    patientName: patient.patientName.trim(),
+    patientAge: Math.floor(patient.patientAge),
+    patientGender: patient.patientGender,
+    keySymptom: patient.keySymptom.trim(),
+    triageCategory: patient.triageCategory,
+  }
+}
+
+export type ParsedTriageState = TriageState

--- a/src/features/triage/state.ts
+++ b/src/features/triage/state.ts
@@ -1,0 +1,49 @@
+import { TRIAGE_STATES, type TriageState } from './types'
+
+const ER_ONLY_STATE_NAMES = new Set([
+  'initial investigation',
+  'drugs/test',
+  'observation',
+  'discharge process',
+  'registration',
+  'doctor assessment',
+  'treatment/observation',
+  'triage',
+])
+
+const ALLOWED_TRANSITIONS: Record<TriageState, TriageState[]> = {
+  empty: ['initial_treatment'],
+  initial_treatment: ['decision_made'],
+  decision_made: ['cleaning'],
+  cleaning: ['empty'],
+}
+
+export function isTriageState(value: string): value is TriageState {
+  return TRIAGE_STATES.includes(value as TriageState)
+}
+
+export function isErOnlyStateName(value: string): boolean {
+  return ER_ONLY_STATE_NAMES.has(value.trim().toLowerCase())
+}
+
+export function getAllowedTriageTransitions(fromState: TriageState): TriageState[] {
+  return ALLOWED_TRANSITIONS[fromState]
+}
+
+export function validateTriageTransition(
+  fromState: TriageState,
+  toState: TriageState
+): { success: true } | { success: false; error: string } {
+  if (!isTriageState(fromState) || !isTriageState(toState)) {
+    return { success: false, error: 'Only approved triage states are allowed.' }
+  }
+
+  if (!ALLOWED_TRANSITIONS[fromState].includes(toState)) {
+    return {
+      success: false,
+      error: `Cannot move triage bed from ${fromState} to ${toState}.`,
+    }
+  }
+
+  return { success: true }
+}

--- a/src/features/triage/triage-bed-lock.ts
+++ b/src/features/triage/triage-bed-lock.ts
@@ -1,0 +1,52 @@
+import type { PoolClient } from 'pg'
+import type { TriageState } from './types'
+
+export type LockedTriageBed = {
+  id: string
+  bedNumber: string
+  state: TriageState
+  lastStateChange: Date
+}
+
+export async function lockTriageBed(
+  client: PoolClient,
+  bedId: string
+): Promise<LockedTriageBed> {
+  const bedResult = await client.query<{ id: string; bedNumber: string; wardCode: string }>(
+    `
+    SELECT b.id, b.bed_number as "bedNumber", w.code as "wardCode"
+    FROM beds b
+    JOIN wards w ON w.id = b.ward_id
+    WHERE b.id = $1 AND b.is_active = true
+    FOR UPDATE OF b
+    `,
+    [bedId]
+  )
+
+  const bed = bedResult.rows[0]
+  if (!bed) throw new Error('Bed not found.')
+  if (bed.wardCode !== 'TRIAGE') throw new Error('Only triage beds can use triage workflow.')
+
+  const statusResult = await client.query<{
+    state: TriageState
+    lastStateChange: Date
+  }>(
+    `SELECT state, last_state_change as "lastStateChange"
+     FROM triage_bed_statuses
+     WHERE bed_id = $1
+     FOR UPDATE`,
+    [bedId]
+  )
+
+  if (statusResult.rows[0]) {
+    return { id: bed.id, bedNumber: bed.bedNumber, ...statusResult.rows[0] }
+  }
+
+  const inserted = await client.query<{ state: TriageState; lastStateChange: Date }>(
+    `INSERT INTO triage_bed_statuses (bed_id, state)
+     VALUES ($1, 'empty')
+     RETURNING state, last_state_change as "lastStateChange"`,
+    [bedId]
+  )
+  return { id: bed.id, bedNumber: bed.bedNumber, ...inserted.rows[0] }
+}

--- a/src/features/triage/types.ts
+++ b/src/features/triage/types.ts
@@ -1,0 +1,85 @@
+export const TRIAGE_BED_NUMBERS = [
+  'TRIAGE-01',
+  'TRIAGE-02',
+  'TRIAGE-03',
+  'TRIAGE-04',
+  'TRIAGE-05',
+  'TRIAGE-06',
+] as const
+
+export const TRIAGE_STATES = [
+  'empty',
+  'initial_treatment',
+  'decision_made',
+  'cleaning',
+] as const
+
+export type TriageState = (typeof TRIAGE_STATES)[number]
+
+export const TRIAGE_STATE_LABELS: Record<TriageState, string> = {
+  empty: 'Empty',
+  initial_treatment: 'Initial Treatment',
+  decision_made: 'Decision Made',
+  cleaning: 'Cleaning',
+}
+
+export const TRIAGE_STATE_STYLES: Record<TriageState, {
+  accent: string
+  border: string
+  badge: string
+}> = {
+  empty: {
+    accent: 'bg-slate-500',
+    border: 'border-slate-300 dark:border-slate-700',
+    badge: 'border-slate-300 bg-slate-100 text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100',
+  },
+  initial_treatment: {
+    accent: 'bg-cyan-500',
+    border: 'border-cyan-300 dark:border-cyan-800',
+    badge: 'border-cyan-300 bg-cyan-100 text-cyan-950 dark:border-cyan-800 dark:bg-cyan-950 dark:text-cyan-100',
+  },
+  decision_made: {
+    accent: 'bg-emerald-500',
+    border: 'border-emerald-300 dark:border-emerald-800',
+    badge: 'border-emerald-300 bg-emerald-100 text-emerald-950 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100',
+  },
+  cleaning: {
+    accent: 'bg-pink-500',
+    border: 'border-pink-300 dark:border-pink-800',
+    badge: 'border-pink-300 bg-pink-100 text-pink-950 dark:border-pink-800 dark:bg-pink-950 dark:text-pink-100',
+  },
+}
+
+export const TRIAGE_CATEGORY_OPTIONS = [
+  'Resuscitation',
+  'Emergent',
+  'Urgent',
+  'Less Urgent',
+  'Non-Urgent',
+] as const
+
+export type TriageCategory = (typeof TRIAGE_CATEGORY_OPTIONS)[number]
+export type PatientGender = 'Male' | 'Female' | 'Other' | 'Unknown'
+
+export interface TriagePatientDetails {
+  patientUhid: string
+  patientIpdId?: string | null
+  patientName: string
+  patientAge: number
+  patientGender: PatientGender
+  keySymptom: string
+  triageCategory: TriageCategory
+}
+
+export interface TriageBed {
+  id: string
+  bedNumber: string
+  state: TriageState
+  lastStateChange: Date
+  patientStartTime: Date | null
+  patient: Partial<TriagePatientDetails> | null
+}
+
+export interface TriageDashboardData {
+  beds: TriageBed[]
+}


### PR DESCRIPTION
## Description
Implements EPIC 25 dedicated triage area workflow.

This PR separates triage from the ER bed dashboard by adding a triage-specific 6-bed workflow for `TRIAGE-01` through `TRIAGE-06`. It introduces dedicated triage state storage, server-side transition validation, audit/state logging, a new `/triage` UI, tests, and database documentation.

Key changes:
- Adds `triage_bed_state`, `triage_bed_statuses`, and `triage_state_logs`.
- Ensures exactly six active physical triage beds exist.
- Adds `src/features/triage/` with triage-specific types, schemas, actions, queries, mutations, UI, and tests.
- Updates `/triage` to use the dedicated triage dashboard instead of the ER bed dashboard.
- Improves triage bed card visibility and readability.
- Documents the triage workflow and schema additions.

## Linked Issue
Closes #349 

## Type
- [x] Feature
- [ ] Bugfix
- [x] Documentation
- [ ] Refactor
- [x] Test

## Checklist

### Code Quality
- [x] No file exceeds 200 lines (except lock files: package-lock.json, yarn.lock, pnpm-lock.yaml)
- [x] Code is properly formatted
- [x] TypeScript types are properly defined
- [x] No ESLint errors or warnings

### Testing
- [x] Tested locally and works as expected
- [x] Added/updated tests if applicable
- [ ] All existing tests pass
- [ ] EPIC 13 reliability verification completed (manual/staging) per `docs/EPIC13_VERIFICATION_CHECKLIST.md` (if applicable)

### Database & Environment
- [ ] Database migrations tested (if applicable)
- [ ] Migration rollback tested (if applicable)
- [x] Environment variables documented in .env.example (if new vars added)
- [x] Database schema changes documented (if applicable)
- [x] No modifications to existing migration files

### Documentation
- [x] Updated documentation if needed
- [ ] ADMIN_HANDBOOK.md updated (if configuration/maintenance/security/operations changed)
- [ ] README updated (if setup process changed)
- [ ] DATABASE_SETUP.md updated (if database changes)
- [x] Code comments added for complex logic

### UI/UX (if applicable)
- [ ] Screenshots attached (if UI changes)
- [ ] Responsive design tested
- [x] Accessibility considerations addressed

## Screenshots
Screenshots not attached yet.