### PR TITLE
feat(triage): add decision outcomes with ER transfer

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -182,6 +182,7 @@ This PR introduces the following migration files; ensure they are reviewed and, 
 - migrations/050_remove_triage_from_er.sql
 - migrations/055_seed_emergency_ward.sql
 - migrations/062_us25_2_er_stage_repair.sql
+- migrations/065_create_triage_decisions.sql
 - migrations/1775303000000_create_triage_workflow.sql
 
 If these migrations alter table structures or seed critical data, update the "Detailed Setup" and any operational runbooks (docs/ADMIN_HANDBOOK.md) with steps required for deployment and rollback.
@@ -191,6 +192,12 @@ If these migrations alter table structures or seed critical data, update the "De
 - `triage_bed_statuses` for current triage bed state
 - `triage_state_logs` for immutable triage state history
 - six active physical triage beds: `TRIAGE-01` through `TRIAGE-06`
+
+`065_create_triage_decisions.sql` adds first-class persistence for triage decision outcomes:
+- `triage_decisions` stores one row per recorded disposition from triage
+- `shift_to_er` decisions require both a destination ER bed and the ER starting stage
+- `shift_to_icu_ot` and `discharge` decisions are stored without ER bed linkage
+- patient snapshot details are copied into the decision record for auditability without creating a separate patient journey id
 
 
 ### Step 4: Seed Initial Data

--- a/docs/ADMIN_HANDBOOK.md
+++ b/docs/ADMIN_HANDBOOK.md
@@ -6,7 +6,7 @@ Administrator runbook for configuration, maintenance, backup/recovery, security,
 - Owner: Platform / System Administration
 - Scope: Configuration, backups, troubleshooting, security, command references
 - Versioning: Git-tracked; update required in release PRs when operations change
-- Last Updated: 2026-05-21 (EPIC 25 Dedicated Triage Workflow)
+- Last Updated: 2026-05-22 (EPIC 25 Triage Decision Outcomes and ER Transfer)
 
 > **Release-specific operational notes** are in [ADMIN_HANDBOOK_RELEASES.md](./ADMIN_HANDBOOK_RELEASES.md).
 
@@ -105,6 +105,7 @@ state model for the physical Triage Area.
 - Adds enum `triage_bed_state` with `empty`, `initial_treatment`, `decision_made`, and `cleaning`.
 - Adds `triage_bed_statuses` for each triage bed's current state.
 - Adds `triage_state_logs` for immutable triage state history.
+- Adds `triage_decisions` to persist triage dispositions and optional ER transfer details.
 - Ensures ward code `TRIAGE` exists and keeps exactly six active physical beds: `TRIAGE-01` through `TRIAGE-06`.
 - Deactivates any extra beds assigned to the `TRIAGE` ward that are not part of the approved six-bed layout.
 
@@ -120,8 +121,10 @@ npm run build
 1. Before production deployment, confirm no intentional extra beds are assigned to ward code `TRIAGE`; the migration marks extras inactive.
 2. After migration, open `/triage` and verify six beds are visible.
 3. Confirm triage shows only the approved states: Empty, Initial Treatment, Decision Made, Cleaning.
-4. Verify assignment and state movement are audit logged with `entity_type = 'triage_bed'`.
-5. Keep ER stage configuration separate; do not add ER-only stages to the triage workflow.
+4. Verify recording a decision outcome creates both audit trail entries and a `triage_decisions` row.
+5. For `Shift to ER`, verify only empty ER beds are offered and the transferred patient lands in the ER starting stage (`Initial Investigation` by default).
+6. Verify assignment and state movement are audit logged with `entity_type = 'triage_bed'`.
+7. Keep ER stage configuration separate; do not add ER-only stages to the triage workflow.
 
 ## 4) Troubleshooting (Common Issues)
 

--- a/docs/TRIAGE_WORKFLOW.md
+++ b/docs/TRIAGE_WORKFLOW.md
@@ -24,7 +24,7 @@ Once a triage bed reaches `decision_made`, staff must record an outcome:
 
 - **Shift to ER** — requires selection of an available ER bed. The patient is
   assigned to the selected ER bed and that bed starts the ER workflow at the
-  configured ER starting stage (default: Registration). The triage bed moves to
+  configured ER starting stage (default: Initial Investigation). The triage bed moves to
   `cleaning`.
 - **Shift to ICU/OT** — records the disposition and moves the triage bed to
   `cleaning`.
@@ -41,5 +41,8 @@ and `discharge process` must not appear in triage.
 - `triage_bed_statuses` stores the current triage state per triage bed.
 - `triage_state_logs` stores immutable triage state history.
 - Patient snapshot fields remain on `beds` for this story.
+- `triage_decisions` stores each recorded disposition with patient snapshot
+  fields and optional ER transfer details. It does not create a separate
+  patient journey ID.
 - Every triage state mutation also writes an `audit_logs` row with
   `entity_type = 'triage_bed'`.

--- a/docs/TRIAGE_WORKFLOW.md
+++ b/docs/TRIAGE_WORKFLOW.md
@@ -18,6 +18,21 @@ Allowed transitions:
 - `decision_made -> cleaning` after the triage decision is completed.
 - `cleaning -> empty` after cleaning is complete.
 
+## Decision Outcomes (After Decision Made)
+
+Once a triage bed reaches `decision_made`, staff must record an outcome:
+
+- **Shift to ER** — requires selection of an available ER bed. The patient is
+  assigned to the selected ER bed and that bed starts the ER workflow at the
+  configured ER starting stage (default: Registration). The triage bed moves to
+  `cleaning`.
+- **Shift to ICU/OT** — records the disposition and moves the triage bed to
+  `cleaning`.
+- **Discharge** — records the disposition and moves the triage bed to
+  `cleaning`.
+
+All decision outcomes are recorded in triage state logs and audit logs.
+
 ER-only stages such as `initial investigation`, `drugs/test`, `observation`,
 and `discharge process` must not appear in triage.
 

--- a/migrations/065_create_triage_decisions.sql
+++ b/migrations/065_create_triage_decisions.sql
@@ -1,0 +1,42 @@
+-- Migration 065: Persist triage decision outcomes
+-- Purpose: EPIC 25 - record triage disposition and optional ER transfer details.
+
+CREATE TABLE IF NOT EXISTS triage_decisions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  triage_bed_id UUID NOT NULL REFERENCES beds(id) ON DELETE RESTRICT,
+  outcome TEXT NOT NULL CHECK (outcome IN ('shift_to_er', 'shift_to_icu_ot', 'discharge')),
+  er_bed_id UUID REFERENCES beds(id) ON DELETE RESTRICT,
+  er_start_stage_id UUID REFERENCES stages(id) ON DELETE RESTRICT,
+  patient_uhid VARCHAR(100),
+  patient_ipd_id VARCHAR(100),
+  patient_name VARCHAR(255),
+  patient_age INTEGER,
+  patient_gender VARCHAR(20),
+  key_symptom VARCHAR(40),
+  triage_category VARCHAR(50),
+  decided_by_user_id UUID NOT NULL REFERENCES users(id),
+  decided_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT triage_decisions_er_required
+    CHECK (
+      (outcome = 'shift_to_er' AND er_bed_id IS NOT NULL AND er_start_stage_id IS NOT NULL)
+      OR
+      (outcome <> 'shift_to_er' AND er_bed_id IS NULL AND er_start_stage_id IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_triage_decisions_triage_bed
+  ON triage_decisions(triage_bed_id, decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_triage_decisions_er_bed
+  ON triage_decisions(er_bed_id, decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_triage_decisions_outcome
+  ON triage_decisions(outcome, decided_at DESC);
+CREATE INDEX IF NOT EXISTS idx_triage_decisions_decided_by
+  ON triage_decisions(decided_by_user_id, decided_at DESC);
+
+COMMENT ON TABLE triage_decisions IS
+  'Recorded triage disposition outcomes. Shift-to-ER rows include target ER bed and ER starting stage.';
+
+-- Down Migration
+-- DROP TABLE IF EXISTS triage_decisions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6562,7 +6562,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6562,6 +6562,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/features/ot-dashboard/actions/__tests__/ot-actions.test.ts
+++ b/src/features/ot-dashboard/actions/__tests__/ot-actions.test.ts
@@ -109,6 +109,7 @@ describe('ot-actions', () => {
       .fn()
       .mockResolvedValueOnce(undefined) // BEGIN
       .mockResolvedValueOnce({ rows: [] }) // active procedure lookup
+      .mockResolvedValueOnce({ rows: [{ status: 'available' }] }) // room status lookup
       .mockResolvedValueOnce(undefined) // ROLLBACK
 
     const release = vi.fn()
@@ -122,6 +123,36 @@ describe('ot-actions', () => {
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/no active procedure/i)
     expect(query).toHaveBeenCalledWith('ROLLBACK')
+    expect(release).toHaveBeenCalled()
+  })
+
+  it('updateOTRoomStatus safely recovers stale ongoing room without active procedure', async () => {
+    vi.mocked(requireWriteRole).mockResolvedValueOnce(SESSION as never)
+
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // active procedure lookup
+      .mockResolvedValueOnce({ rows: [{ status: 'ongoing' }] }) // room status lookup
+      .mockResolvedValueOnce(undefined) // UPDATE ot_rooms
+      .mockResolvedValueOnce(undefined) // COMMIT
+
+    const release = vi.fn()
+    vi.mocked(pool.connect).mockResolvedValueOnce({ query, release } as never)
+
+    const result = await updateOTRoomStatus({
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      status: 'available',
+    })
+
+    expect(result.success).toBe(true)
+    expect(logAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ actionType: 'OT_ROOM_RECOVERY' })
+    )
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE ot_rooms'),
+      ['available', 'nurse-1', '550e8400-e29b-41d4-a716-446655440000']
+    )
     expect(release).toHaveBeenCalled()
   })
 

--- a/src/features/ot-dashboard/actions/ot-actions.ts
+++ b/src/features/ot-dashboard/actions/ot-actions.ts
@@ -2,6 +2,7 @@
 
 import pool from '@/shared/lib/db'
 import { requireWriteRole } from '@/shared/lib/auth'
+import { logAudit } from '@/shared/lib/audit'
 import { logger } from '@/shared/config/logger'
 import type { OTRoom, OTGridData } from '../types/ot'
 import { runProcedureTransition } from '../lib/ot-procedure-mutations'
@@ -79,16 +80,18 @@ export async function updateOTRoomStatus(input: {
     })
 
     const client = await pool.connect()
+    let auditsToWrite: Parameters<typeof logAudit>[0][] = []
     try {
       await client.query('BEGIN')
 
-      const transitionError = await runProcedureTransition(client, input, {
+      const transitionResult = await runProcedureTransition(client, input, {
         userId: session.userId,
       })
-      if (transitionError) {
+      if (!transitionResult.success) {
         await client.query('ROLLBACK')
-        return transitionError
+        return transitionResult
       }
+      auditsToWrite = transitionResult.audits
 
       await client.query(
         `UPDATE ot_rooms
@@ -106,6 +109,10 @@ export async function updateOTRoomStatus(input: {
       throw txError
     } finally {
       client.release()
+    }
+
+    for (const audit of auditsToWrite) {
+      await logAudit(audit)
     }
 
     logger.info('OT room status updated', {

--- a/src/features/ot-dashboard/lib/ot-procedure-mutations.ts
+++ b/src/features/ot-dashboard/lib/ot-procedure-mutations.ts
@@ -1,6 +1,16 @@
 import type { PoolClient } from 'pg'
-import { logAudit } from '@/shared/lib/audit'
+import type { AuditLogEntry } from '@/shared/lib/audit'
 import { OTProcedureStartSchema, OTProcedureFinishSchema } from '../schemas/ot-procedure-schema'
+
+type TransitionSuccess = {
+  success: true
+  audits: AuditLogEntry[]
+}
+
+type TransitionFailure = {
+  success: false
+  error: string
+}
 
 export async function runProcedureTransition(
   client: PoolClient,
@@ -10,7 +20,7 @@ export async function runProcedureTransition(
     procedureName?: string
   },
   session: { userId: string }
-): Promise<{ success: false; error: string } | null> {
+): Promise<TransitionSuccess | TransitionFailure> {
   if (input.status === 'ongoing') {
     const parsed = OTProcedureStartSchema.safeParse({
       roomId: input.roomId,
@@ -51,18 +61,21 @@ export async function runProcedureTransition(
       [input.roomId, parsed.data.procedureName, null]
     )
 
-    await logAudit({
-      actionType: 'OT_PROCEDURE_START',
-      entityType: 'ot_procedure',
-      entityId: input.roomId,
-      performedBy: session.userId,
-      metadata: {
-        roomId: input.roomId,
-        procedureName: parsed.data.procedureName,
-      },
-    })
-
-    return null
+    return {
+      success: true,
+      audits: [
+        {
+          actionType: 'OT_PROCEDURE_START',
+          entityType: 'ot_procedure',
+          entityId: input.roomId,
+          performedBy: session.userId,
+          metadata: {
+            roomId: input.roomId,
+            procedureName: parsed.data.procedureName,
+          },
+        },
+      ],
+    }
   }
 
   const parsed = OTProcedureFinishSchema.safeParse({ roomId: input.roomId })
@@ -86,6 +99,33 @@ export async function runProcedureTransition(
   )
 
   if (activeProcedure.rows.length === 0) {
+    const roomResult = await client.query<{ status: 'available' | 'ongoing' }>(
+      `SELECT status
+       FROM ot_rooms
+       WHERE id = $1
+       FOR UPDATE`,
+      [input.roomId]
+    )
+
+    if (roomResult.rows[0]?.status === 'ongoing') {
+      return {
+        success: true,
+        audits: [
+          {
+            actionType: 'OT_ROOM_RECOVERY',
+            entityType: 'ot_room',
+            entityId: input.roomId,
+            performedBy: session.userId,
+            reason: 'Recovered stale ongoing OT room without active procedure row',
+            metadata: {
+              roomId: input.roomId,
+              recoveryType: 'stale_ongoing_without_active_procedure',
+            },
+          },
+        ],
+      }
+    }
+
     return {
       success: false,
       error: 'No active procedure found for this OT room',
@@ -103,15 +143,18 @@ export async function runProcedureTransition(
     [activeProcedure.rows[0].id]
   )
 
-  await logAudit({
-    actionType: 'OT_PROCEDURE_FINISH',
-    entityType: 'ot_procedure',
-    entityId: activeProcedure.rows[0].id,
-    performedBy: session.userId,
-    metadata: {
-      roomId: input.roomId,
-    },
-  })
-
-  return null
+  return {
+    success: true,
+    audits: [
+      {
+        actionType: 'OT_PROCEDURE_FINISH',
+        entityType: 'ot_procedure',
+        entityId: activeProcedure.rows[0].id,
+        performedBy: session.userId,
+        metadata: {
+          roomId: input.roomId,
+        },
+      },
+    ],
+  }
 }

--- a/src/features/triage/__tests__/dashboard.test.tsx
+++ b/src/features/triage/__tests__/dashboard.test.tsx
@@ -9,6 +9,8 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('../actions', () => ({
   assignTriagePatient: vi.fn(),
+  completeTriageDecision: vi.fn(),
+  fetchAvailableErBeds: vi.fn().mockResolvedValue({ success: true, data: { beds: [] } }),
   transitionTriageBed: vi.fn(),
   updateTriagePatientDetails: vi.fn(),
 }))
@@ -63,7 +65,7 @@ describe('TriageDashboardClient', () => {
 
     expect(screen.getByText('Assign Patient')).toBeInTheDocument()
     expect(screen.getByText('Mark Decision Made')).toBeInTheDocument()
-    expect(screen.getByText('Move to Cleaning')).toBeInTheDocument()
+    expect(screen.getByText('Record Decision Outcome')).toBeInTheDocument()
     expect(screen.getByText('Cleaning Complete')).toBeInTheDocument()
   })
 })

--- a/src/features/triage/__tests__/dashboard.test.tsx
+++ b/src/features/triage/__tests__/dashboard.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { TriageDashboardClient } from '../components/TriageDashboardClient'
+import { completeTriageDecision } from '../actions'
 import type { TriageBed, TriageState } from '../types'
 
 vi.mock('next/navigation', () => ({
@@ -67,5 +69,20 @@ describe('TriageDashboardClient', () => {
     expect(screen.getByText('Mark Decision Made')).toBeInTheDocument()
     expect(screen.getByText('Record Decision Outcome')).toBeInTheDocument()
     expect(screen.getByText('Cleaning Complete')).toBeInTheDocument()
+  })
+
+  it('shows decision field validation errors in the modal', async () => {
+    vi.mocked(completeTriageDecision).mockResolvedValueOnce({
+      success: false,
+      errors: { erBedId: ['Select an ER bed for transfer.'] },
+    })
+
+    render(<TriageDashboardClient initialBeds={[makeBed(1, 'decision_made')]} />)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Record Decision Outcome'))
+    await user.click(screen.getByText('Record Outcome'))
+
+    expect(await screen.findByText('Select an ER bed for transfer.')).toBeInTheDocument()
   })
 })

--- a/src/features/triage/__tests__/decision-helpers.test.ts
+++ b/src/features/triage/__tests__/decision-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveErStartingStage } from '../decision-helpers'
+
+describe('triage decision helpers', () => {
+  it('resolves the active U.S 25.2 ER starting stage', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{ id: 'stage-initial-investigation', name: 'Initial Investigation' }],
+    })
+
+    const result = await resolveErStartingStage({ query } as never)
+
+    expect(result).toEqual({ id: 'stage-initial-investigation', name: 'Initial Investigation' })
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("WHEN 'initial investigation' THEN 1"),
+      [['initial investigation', 'initial treatment', 'drugs/test']]
+    )
+  })
+})

--- a/src/features/triage/__tests__/decision-mutations.test.ts
+++ b/src/features/triage/__tests__/decision-mutations.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { connectMock, queryMock, releaseMock } = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  queryMock: vi.fn(),
+  releaseMock: vi.fn(),
+}))
+
+vi.mock('@/shared/lib/db', () => ({
+  __esModule: true,
+  default: { connect: connectMock },
+}))
+
+vi.mock('@/shared/config/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+import { completeTriageDecisionInDB } from '../decision-mutations'
+
+const TRIAGE_BED_ID = '11111111-1111-4111-8111-111111111111'
+const ER_BED_ID = '33333333-3333-4333-8333-333333333333'
+const USER_ID = '22222222-2222-4222-8222-222222222222'
+const EMPTY_STAGE_ID = '44444444-4444-4444-8444-444444444444'
+const ER_START_STAGE_ID = '55555555-5555-4555-8555-555555555555'
+
+const patient = {
+  patientUhid: 'UH-1',
+  patientIpdId: 'IPD-1',
+  patientName: 'Jane Doe',
+  patientAge: 42,
+  patientGender: 'Female',
+  keySymptom: 'Chest pain',
+  triageCategory: 'Urgent',
+}
+
+function setupClient() {
+  queryMock.mockReset()
+  releaseMock.mockReset()
+  queryMock.mockResolvedValue({ rows: [], rowCount: 0 })
+  connectMock.mockResolvedValue({ query: queryMock, release: releaseMock })
+}
+
+function mockDecisionMadeTriageBed() {
+  queryMock
+    .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    .mockResolvedValueOnce({
+      rows: [{ id: TRIAGE_BED_ID, bedNumber: 'TRIAGE-01', wardCode: 'TRIAGE' }],
+    })
+    .mockResolvedValueOnce({
+      rows: [{ state: 'decision_made', lastStateChange: new Date('2026-05-21T08:00:00Z') }],
+    })
+    .mockResolvedValueOnce({ rows: [patient] })
+}
+
+describe('completeTriageDecisionInDB', () => {
+  beforeEach(() => setupClient())
+
+  it('transfers a triage patient to an available ER bed transactionally', async () => {
+    mockDecisionMadeTriageBed()
+    queryMock
+      .mockResolvedValueOnce({
+        rows: [{
+          id: ER_BED_ID,
+          bedNumber: 'ER-01',
+          currentStageId: EMPTY_STAGE_ID,
+          currentStageName: 'Empty',
+          lastStageChange: new Date('2026-05-21T07:30:00Z'),
+          isOccupied: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: ER_START_STAGE_ID, name: 'Initial Investigation' }],
+      })
+
+    await completeTriageDecisionInDB({
+      bedId: TRIAGE_BED_ID,
+      outcome: 'shift_to_er',
+      erBedId: ER_BED_ID,
+      userId: USER_ID,
+    })
+
+    const sql = queryMock.mock.calls.map((call) => String(call[0]))
+    expect(sql[0]).toBe('BEGIN')
+    expect(sql.some((text) => text.includes('FOR UPDATE OF b'))).toBe(true)
+    expect(sql.some((text) => text.includes('INSERT INTO triage_decisions'))).toBe(true)
+    expect(sql.some((text) => text.includes('INSERT INTO bed_stage_logs'))).toBe(true)
+    expect(sql.some((text) => text.includes('INSERT INTO audit_logs'))).toBe(true)
+    expect(sql.at(-1)).toBe('COMMIT')
+
+    const erUpdateCall = queryMock.mock.calls.find((call) =>
+      String(call[0]).includes('UPDATE beds') && String(call[0]).includes('current_stage_id = $8')
+    )
+    expect(erUpdateCall?.[1]).toEqual(expect.arrayContaining([ER_START_STAGE_ID, ER_BED_ID]))
+
+    const decisionCall = queryMock.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO triage_decisions')
+    )
+    expect(decisionCall?.[1]).toEqual(expect.arrayContaining([
+      TRIAGE_BED_ID,
+      'shift_to_er',
+      ER_BED_ID,
+      ER_START_STAGE_ID,
+      patient.patientUhid,
+      USER_ID,
+    ]))
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects occupied ER beds and rolls back without disposition writes', async () => {
+    mockDecisionMadeTriageBed()
+    queryMock.mockResolvedValueOnce({
+      rows: [{
+        id: ER_BED_ID,
+        bedNumber: 'ER-01',
+        currentStageId: EMPTY_STAGE_ID,
+        currentStageName: 'Empty',
+        lastStageChange: new Date('2026-05-21T07:30:00Z'),
+        isOccupied: true,
+      }],
+    })
+
+    await expect(completeTriageDecisionInDB({
+      bedId: TRIAGE_BED_ID,
+      outcome: 'shift_to_er',
+      erBedId: ER_BED_ID,
+      userId: USER_ID,
+    })).rejects.toThrow('Selected ER bed is not available.')
+
+    const sql = queryMock.mock.calls.map((call) => String(call[0]))
+    expect(sql.some((text) => text.includes('INSERT INTO triage_decisions'))).toBe(false)
+    expect(sql.some((text) => text.includes('INSERT INTO bed_stage_logs'))).toBe(false)
+    expect(sql).toContain('ROLLBACK')
+  })
+
+  it('records non-ER dispositions without assigning an ER bed', async () => {
+    mockDecisionMadeTriageBed()
+
+    await completeTriageDecisionInDB({
+      bedId: TRIAGE_BED_ID,
+      outcome: 'discharge',
+      erBedId: ER_BED_ID,
+      userId: USER_ID,
+    })
+
+    const sql = queryMock.mock.calls.map((call) => String(call[0]))
+    expect(sql.some((text) => text.includes("JOIN wards w ON w.id = b.ward_id AND w.code = 'ER'"))).toBe(false)
+
+    const decisionCall = queryMock.mock.calls.find((call) =>
+      String(call[0]).includes('INSERT INTO triage_decisions')
+    )
+    expect(decisionCall?.[1]).toEqual(expect.arrayContaining([
+      TRIAGE_BED_ID,
+      'discharge',
+      null,
+      null,
+      patient.patientUhid,
+      USER_ID,
+    ]))
+    expect(sql.at(-1)).toBe('COMMIT')
+  })
+})

--- a/src/features/triage/actions.ts
+++ b/src/features/triage/actions.ts
@@ -15,10 +15,10 @@ import {
 } from './schemas'
 import {
   assignPatientInDB,
-  completeTriageDecisionInDB,
   transitionTriageBedInDB,
   updatePatientInDB,
 } from './mutations'
+import { completeTriageDecisionInDB } from './decision-mutations'
 import { getAvailableErBeds } from './queries'
 
 type ActionResult = { success: boolean; error?: string; errors?: Record<string, string[]> }

--- a/src/features/triage/actions.ts
+++ b/src/features/triage/actions.ts
@@ -5,17 +5,21 @@ import { requireRole } from '@/shared/lib/auth'
 import {
   assignTriagePatientSchema,
   normalizePatientDetails,
+  triageDecisionSchema,
   transitionTriageBedSchema,
   updateTriageDetailsSchema,
   type AssignTriagePatientInput,
+  type TriageDecisionInput,
   type TransitionTriageBedInput,
   type UpdateTriageDetailsInput,
 } from './schemas'
 import {
   assignPatientInDB,
+  completeTriageDecisionInDB,
   transitionTriageBedInDB,
   updatePatientInDB,
 } from './mutations'
+import { getAvailableErBeds } from './queries'
 
 type ActionResult = { success: boolean; error?: string; errors?: Record<string, string[]> }
 
@@ -81,5 +85,36 @@ export async function transitionTriageBed(input: TransitionTriageBedInput): Prom
     return { success: true }
   } catch (error) {
     return { success: false, error: error instanceof Error ? error.message : 'State update failed' }
+  }
+}
+
+export async function fetchAvailableErBeds(): Promise<{
+  success: boolean
+  data?: { beds: { id: string; bedNumber: string; currentStageName: string }[] }
+  error?: string
+}> {
+  return getAvailableErBeds()
+}
+
+export async function completeTriageDecision(input: TriageDecisionInput): Promise<ActionResult> {
+  try {
+    const session = await requireRole(['nurse', 'supervisor', 'admin'])
+    const parsed = triageDecisionSchema.safeParse(input)
+    if (!parsed.success) return { success: false, errors: flattenErrors(parsed.error) }
+
+    await completeTriageDecisionInDB({
+      bedId: parsed.data.bedId,
+      outcome: parsed.data.outcome,
+      erBedId: parsed.data.erBedId,
+      userId: session.userId,
+    })
+
+    revalidatePath('/triage')
+    revalidatePath('/dashboard')
+    revalidatePath('/supervisor')
+    revalidatePath('/admin')
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Decision update failed' }
   }
 }

--- a/src/features/triage/components/TriageBedCard.tsx
+++ b/src/features/triage/components/TriageBedCard.tsx
@@ -12,6 +12,7 @@ interface TriageBedCardProps {
   isPending: boolean
   onAssign: (bed: TriageBed) => void
   onEdit: (bed: TriageBed) => void
+  onDecision: (bed: TriageBed) => void
   onTransition: (bed: TriageBed) => void
 }
 
@@ -28,6 +29,7 @@ export function TriageBedCard({
   isPending,
   onAssign,
   onEdit,
+  onDecision,
   onTransition,
 }: TriageBedCardProps) {
   const [now, setNow] = useState(() => new Date())
@@ -89,8 +91,8 @@ export function TriageBedCard({
             </Button>
           )}
           {bed.state === 'decision_made' && (
-            <Button size="sm" onClick={() => onTransition(bed)} disabled={isPending}>
-              <Eraser className="h-4 w-4" /> Move to Cleaning
+            <Button size="sm" onClick={() => onDecision(bed)} disabled={isPending}>
+              <Eraser className="h-4 w-4" /> Record Decision Outcome
             </Button>
           )}
           {bed.state === 'cleaning' && (

--- a/src/features/triage/components/TriageDashboardClient.tsx
+++ b/src/features/triage/components/TriageDashboardClient.tsx
@@ -2,14 +2,22 @@
 
 import { useEffect, useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
-import { assignTriagePatient, transitionTriageBed, updateTriagePatientDetails } from '../actions'
+import {
+  assignTriagePatient,
+  completeTriageDecision,
+  fetchAvailableErBeds,
+  transitionTriageBed,
+  updateTriagePatientDetails,
+} from '../actions'
 import {
   TRIAGE_STATE_LABELS,
+  type ErBedOption,
   type TriageBed,
   type TriagePatientDetails,
   type TriageState,
 } from '../types'
 import { TriageBedCard } from './TriageBedCard'
+import { TriageDecisionModal } from './TriageDecisionModal'
 import { TriagePatientModal } from './TriagePatientModal'
 
 interface TriageDashboardClientProps {
@@ -20,7 +28,6 @@ type ModalState = { bed: TriageBed; mode: 'assign' | 'edit' } | null
 
 const NEXT_STATE: Partial<Record<TriageState, TriageState>> = {
   initial_treatment: 'decision_made',
-  decision_made: 'cleaning',
   cleaning: 'empty',
 }
 
@@ -32,6 +39,9 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
   const router = useRouter()
   const [beds, setBeds] = useState(initialBeds)
   const [modalState, setModalState] = useState<ModalState>(null)
+  const [decisionBed, setDecisionBed] = useState<TriageBed | null>(null)
+  const [erBeds, setErBeds] = useState<ErBedOption[]>([])
+  const [isLoadingErBeds, setIsLoadingErBeds] = useState(false)
   const [pendingBedId, setPendingBedId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
@@ -48,8 +58,27 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
   const refreshAfterSuccess = () => {
     setError(null)
     setModalState(null)
+    setDecisionBed(null)
     router.refresh()
   }
+
+  const loadErBeds = async () => {
+    setError(null)
+    setIsLoadingErBeds(true)
+    const result = await fetchAvailableErBeds()
+    if (!result.success) {
+      setError(result.error || 'Failed to load ER beds.')
+      setErBeds([])
+    } else {
+      setErBeds(result.data?.beds ?? [])
+    }
+    setIsLoadingErBeds(false)
+  }
+
+  useEffect(() => {
+    if (!decisionBed) return
+    void loadErBeds()
+  }, [decisionBed])
 
   const handlePatientSubmit = (bedId: string, patient: TriagePatientDetails) => {
     const mode = modalState?.mode
@@ -82,6 +111,23 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
     })
   }
 
+  const handleDecisionSubmit = (
+    bedId: string,
+    outcome: 'shift_to_er' | 'shift_to_icu_ot' | 'discharge',
+    erBedId?: string | null
+  ) => {
+    setPendingBedId(bedId)
+    startTransition(async () => {
+      const result = await completeTriageDecision({ bedId, outcome, erBedId: erBedId ?? null })
+      setPendingBedId(null)
+      if (!result.success) {
+        setError(result.error || 'Failed to record decision outcome.')
+        return
+      }
+      refreshAfterSuccess()
+    })
+  }
+
   return (
     <div className="space-y-5">
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
@@ -91,7 +137,7 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
         <Summary label="Empty" value={counts.empty} />
       </div>
 
-      {error && !modalState && (
+      {error && !modalState && !decisionBed && (
         <div className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {error}
         </div>
@@ -105,6 +151,7 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
             isPending={(isPending && pendingBedId === bed.id) || Boolean(pendingBedId)}
             onAssign={(nextBed) => { setError(null); setModalState({ bed: nextBed, mode: 'assign' }) }}
             onEdit={(nextBed) => { setError(null); setModalState({ bed: nextBed, mode: 'edit' }) }}
+            onDecision={(nextBed) => { setError(null); setDecisionBed(nextBed) }}
             onTransition={handleTransition}
           />
         ))}
@@ -118,6 +165,18 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
         error={modalState ? error : null}
         onClose={() => { setError(null); setModalState(null) }}
         onSubmit={handlePatientSubmit}
+      />
+
+      <TriageDecisionModal
+        bed={decisionBed}
+        isOpen={Boolean(decisionBed)}
+        isSubmitting={isPending}
+        isLoadingErBeds={isLoadingErBeds}
+        error={decisionBed ? error : null}
+        erBeds={erBeds}
+        onClose={() => { setError(null); setDecisionBed(null) }}
+        onSubmit={handleDecisionSubmit}
+        onRefreshErBeds={loadErBeds}
       />
     </div>
   )

--- a/src/features/triage/components/TriageDashboardClient.tsx
+++ b/src/features/triage/components/TriageDashboardClient.tsx
@@ -25,6 +25,7 @@ interface TriageDashboardClientProps {
 }
 
 type ModalState = { bed: TriageBed; mode: 'assign' | 'edit' } | null
+type ActionResult = { success: boolean; error?: string; errors?: Record<string, string[]> }
 
 const NEXT_STATE: Partial<Record<TriageState, TriageState>> = {
   initial_treatment: 'decision_made',
@@ -33,6 +34,13 @@ const NEXT_STATE: Partial<Record<TriageState, TriageState>> = {
 
 function nextActionState(bed: TriageBed) {
   return NEXT_STATE[bed.state]
+}
+
+function actionError(result: ActionResult, fallback: string) {
+  const fieldError = result.errors
+    ? Object.values(result.errors).flat().find(Boolean)
+    : undefined
+  return result.error || fieldError || fallback
 }
 
 export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProps) {
@@ -89,7 +97,7 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
         : await updateTriagePatientDetails({ bedId, patient })
       setPendingBedId(null)
       if (!result.success) {
-        setError(result.error || 'Please check the triage details.')
+        setError(actionError(result, 'Please check the triage details.'))
         return
       }
       refreshAfterSuccess()
@@ -104,7 +112,7 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
       const result = await transitionTriageBed({ bedId: bed.id, toState })
       setPendingBedId(null)
       if (!result.success) {
-        setError(result.error || `Could not move bed to ${TRIAGE_STATE_LABELS[toState]}.`)
+        setError(actionError(result, `Could not move bed to ${TRIAGE_STATE_LABELS[toState]}.`))
         return
       }
       refreshAfterSuccess()
@@ -121,7 +129,7 @@ export function TriageDashboardClient({ initialBeds }: TriageDashboardClientProp
       const result = await completeTriageDecision({ bedId, outcome, erBedId: erBedId ?? null })
       setPendingBedId(null)
       if (!result.success) {
-        setError(result.error || 'Failed to record decision outcome.')
+        setError(actionError(result, 'Failed to record decision outcome.'))
         return
       }
       refreshAfterSuccess()

--- a/src/features/triage/components/TriageDecisionModal.tsx
+++ b/src/features/triage/components/TriageDecisionModal.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import { Button } from '@/shared/components/ui/button'
+import { Label } from '@/shared/components/ui/label'
+import { type ErBedOption, type TriageBed, type TriageDecisionOutcome, TRIAGE_DECISION_LABELS, TRIAGE_DECISION_OUTCOMES } from '../types'
+
+interface TriageDecisionModalProps {
+  bed: TriageBed | null
+  isOpen: boolean
+  isSubmitting: boolean
+  isLoadingErBeds: boolean
+  error: string | null
+  erBeds: ErBedOption[]
+  onClose: () => void
+  onSubmit: (bedId: string, outcome: TriageDecisionOutcome, erBedId?: string | null) => void
+  onRefreshErBeds: () => void
+}
+
+export function TriageDecisionModal({
+  bed,
+  isOpen,
+  isSubmitting,
+  isLoadingErBeds,
+  error,
+  erBeds,
+  onClose,
+  onSubmit,
+  onRefreshErBeds,
+}: TriageDecisionModalProps) {
+  const [outcome, setOutcome] = useState<TriageDecisionOutcome>('shift_to_er')
+  const [erBedId, setErBedId] = useState<string>('')
+
+  useEffect(() => {
+    if (isOpen) {
+      setOutcome('shift_to_er')
+      setErBedId('')
+    }
+  }, [isOpen, bed?.id])
+
+  if (!isOpen || !bed) return null
+
+  const isErTransfer = outcome === 'shift_to_er'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="triage-decision-title"
+    >
+      <div className="w-full max-w-xl rounded-lg border border-border bg-background shadow-xl">
+        <div className="flex items-center justify-between border-b border-border p-4">
+          <div>
+            <h2 id="triage-decision-title" className="text-lg font-semibold">Decision Outcome - {bed.bedNumber}</h2>
+            <p className="text-sm text-muted-foreground">Record the next step after triage decision is made.</p>
+          </div>
+          <Button type="button" variant="ghost" size="icon" onClick={onClose} disabled={isSubmitting}>
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <form
+          className="space-y-4 p-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            onSubmit(bed.id, outcome, isErTransfer ? (erBedId || null) : null)
+          }}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="triageOutcome">Decision outcome</Label>
+            <select
+              id="triageOutcome"
+              value={outcome}
+              disabled={isSubmitting}
+              onChange={(event) => setOutcome(event.target.value as TriageDecisionOutcome)}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              {TRIAGE_DECISION_OUTCOMES.map((option) => (
+                <option key={option} value={option}>{TRIAGE_DECISION_LABELS[option]}</option>
+              ))}
+            </select>
+          </div>
+
+          {isErTransfer && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <Label htmlFor="erBedSelect">Select ER bed</Label>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={onRefreshErBeds}
+                  disabled={isSubmitting || isLoadingErBeds}
+                >
+                  Refresh
+                </Button>
+              </div>
+              <select
+                id="erBedSelect"
+                value={erBedId}
+                disabled={isSubmitting || isLoadingErBeds}
+                onChange={(event) => setErBedId(event.target.value)}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              >
+                <option value="">Select an available ER bed</option>
+                {erBeds.map((erBed) => (
+                  <option key={erBed.id} value={erBed.id}>
+                    {erBed.bedNumber} ({erBed.currentStageName})
+                  </option>
+                ))}
+              </select>
+              {isLoadingErBeds && (
+                <p className="text-xs text-muted-foreground">Loading ER beds...</p>
+              )}
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive" role="alert">{error}</p>}
+
+          <div className="flex justify-end gap-2 border-t border-border pt-4">
+            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={isSubmitting}>
+              Record Outcome
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/features/triage/decision-helpers.ts
+++ b/src/features/triage/decision-helpers.ts
@@ -1,0 +1,99 @@
+import type { PoolClient } from 'pg'
+
+type TriagePatientSnapshot = {
+  patientUhid: string | null
+  patientIpdId: string | null
+  patientName: string | null
+  patientAge: number | null
+  patientGender: string | null
+  keySymptom: string | null
+  triageCategory: string | null
+}
+
+export async function getTriagePatientSnapshot(
+  client: PoolClient,
+  bedId: string
+): Promise<TriagePatientSnapshot> {
+  const result = await client.query<TriagePatientSnapshot>(
+    `SELECT
+        patient_uhid as "patientUhid",
+        patient_ipd_id as "patientIpdId",
+        patient_name as "patientName",
+        patient_age as "patientAge",
+        patient_gender as "patientGender",
+        key_symptom as "keySymptom",
+        triage_category as "triageCategory"
+     FROM beds
+     WHERE id = $1`,
+    [bedId]
+  )
+
+  if (!result.rows[0]) {
+    throw new Error('Triage patient details not found.')
+  }
+
+  return result.rows[0]
+}
+
+type LockedErBed = {
+  id: string
+  bedNumber: string
+  currentStageId: string | null
+  currentStageName: string | null
+  lastStageChange: Date | null
+  isOccupied: boolean
+}
+
+export async function lockErBed(client: PoolClient, bedId: string): Promise<LockedErBed> {
+  const result = await client.query<LockedErBed>(
+    `
+    SELECT
+      b.id,
+      b.bed_number as "bedNumber",
+      b.current_stage_id as "currentStageId",
+      s.name as "currentStageName",
+      b.last_stage_change as "lastStageChange",
+      b.is_occupied as "isOccupied"
+    FROM beds b
+    JOIN wards w ON w.id = b.ward_id AND w.code = 'ER'
+    LEFT JOIN stages s ON s.id = b.current_stage_id
+    WHERE b.id = $1 AND b.is_active = true
+    FOR UPDATE OF b
+    `,
+    [bedId]
+  )
+
+  const bed = result.rows[0]
+  if (!bed) throw new Error('ER bed not found or inactive.')
+  return bed
+}
+
+export async function resolveErStartingStage(
+  client: PoolClient
+): Promise<{ id: string; name: string }> {
+  const result = await client.query<{ id: string; name: string }>(
+    `
+    SELECT id, name
+    FROM stages
+    WHERE is_active = true AND LOWER(name) = ANY($1)
+    ORDER BY CASE LOWER(name)
+      WHEN 'registration' THEN 1
+      WHEN 'doctor assessment' THEN 2
+      WHEN 'treatment/observation' THEN 3
+      ELSE 99
+    END
+    LIMIT 1
+    `,
+    [[
+      'registration',
+      'doctor assessment',
+      'treatment/observation',
+    ]]
+  )
+
+  if (!result.rows[0]) {
+    throw new Error('ER starting stage not found.')
+  }
+
+  return result.rows[0]
+}

--- a/src/features/triage/decision-helpers.ts
+++ b/src/features/triage/decision-helpers.ts
@@ -77,17 +77,17 @@ export async function resolveErStartingStage(
     FROM stages
     WHERE is_active = true AND LOWER(name) = ANY($1)
     ORDER BY CASE LOWER(name)
-      WHEN 'registration' THEN 1
-      WHEN 'doctor assessment' THEN 2
-      WHEN 'treatment/observation' THEN 3
+      WHEN 'initial investigation' THEN 1
+      WHEN 'initial treatment' THEN 2
+      WHEN 'drugs/test' THEN 3
       ELSE 99
     END
     LIMIT 1
     `,
     [[
-      'registration',
-      'doctor assessment',
-      'treatment/observation',
+      'initial investigation',
+      'initial treatment',
+      'drugs/test',
     ]]
   )
 

--- a/src/features/triage/decision-mutations.ts
+++ b/src/features/triage/decision-mutations.ts
@@ -1,0 +1,164 @@
+import pool from '@/shared/lib/db'
+import { logger } from '@/shared/config/logger'
+import type { TriageDecisionOutcome } from './types'
+import { validateTriageTransition } from './state'
+import { lockTriageBed } from './triage-bed-lock'
+import {
+  getTriagePatientSnapshot,
+  lockErBed,
+  resolveErStartingStage,
+} from './decision-helpers'
+import {
+  clearPatient,
+  setTriageState,
+  writeAudit,
+  writeTriageLog,
+} from './mutations'
+import {
+  INSERT_AUDIT_LOG_SQL,
+  INSERT_BED_STAGE_LOG_SQL,
+} from '@/features/bed-dashboard/lib/bed-mutations.constants'
+
+export async function completeTriageDecisionInDB(params: {
+  bedId: string
+  outcome: TriageDecisionOutcome
+  erBedId?: string | null
+  userId: string
+}) {
+  const client = await pool.connect()
+  const { bedId, outcome, erBedId, userId } = params
+
+  try {
+    await client.query('BEGIN')
+
+    const bed = await lockTriageBed(client, bedId)
+    if (bed.state !== 'decision_made') {
+      throw new Error('Decision outcomes can only be recorded for decision made beds.')
+    }
+
+    const validation = validateTriageTransition(bed.state, 'cleaning')
+    if (validation.success === false) throw new Error(validation.error)
+
+    const patient = await getTriagePatientSnapshot(client, bedId)
+    if (!patient.patientUhid && !patient.patientName) {
+      throw new Error('Triage patient details are missing; cannot transfer.')
+    }
+
+    let erBedNumber: string | null = null
+    let erStageId: string | null = null
+
+    if (outcome === 'shift_to_er') {
+      if (!erBedId) throw new Error('ER bed selection is required.')
+
+      const erBed = await lockErBed(client, erBedId)
+      const stageName = (erBed.currentStageName || '').trim().toLowerCase()
+      if (erBed.isOccupied || stageName !== 'empty') {
+        throw new Error('Selected ER bed is not available.')
+      }
+
+      const erStartStage = await resolveErStartingStage(client)
+      erStageId = erStartStage.id
+      erBedNumber = erBed.bedNumber
+
+      const triageInfo = {
+        patientUhid: patient.patientUhid ?? undefined,
+        patientIpdId: patient.patientIpdId ?? undefined,
+        patientName: patient.patientName ?? undefined,
+        patientAge: patient.patientAge ?? undefined,
+        patientGender: patient.patientGender ?? undefined,
+        keySymptom: patient.keySymptom ?? undefined,
+        triageCategory: patient.triageCategory ?? undefined,
+      }
+
+      await client.query(
+        `UPDATE beds
+         SET patient_uhid = $1,
+             patient_ipd_id = $2,
+             patient_name = $3,
+             patient_age = $4,
+             patient_gender = $5,
+             key_symptom = $6,
+             triage_category = $7,
+             patient_start_time = NOW(),
+             is_occupied = true,
+             current_stage_id = $8,
+             last_stage_change = NOW(),
+             metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{triageInfo}', $9::jsonb, true),
+             updated_at = NOW()
+         WHERE id = $10`,
+        [
+          patient.patientUhid,
+          patient.patientIpdId,
+          patient.patientName,
+          patient.patientAge,
+          patient.patientGender,
+          patient.keySymptom,
+          patient.triageCategory,
+          erStartStage.id,
+          JSON.stringify(triageInfo),
+          erBedId,
+        ]
+      )
+
+      const durationInPreviousStageMs = erBed.lastStageChange
+        ? Date.now() - new Date(erBed.lastStageChange).getTime()
+        : null
+
+      await client.query(INSERT_BED_STAGE_LOG_SQL, [
+        erBedId,
+        erBed.currentStageId,
+        erStartStage.id,
+        userId,
+        durationInPreviousStageMs,
+        'Transferred from triage',
+        null,
+        null,
+      ])
+
+      await client.query(INSERT_AUDIT_LOG_SQL, [
+        'UPDATE',
+        'bed',
+        erBedId,
+        userId,
+        JSON.stringify({
+          fromStageId: erBed.currentStageId,
+          toStageId: erStartStage.id,
+          isOccupied: true,
+        }),
+        'ER bed assigned from triage',
+        JSON.stringify({
+          source: 'triage-transfer',
+          triageBedId: bedId,
+          triageBedNumber: bed.bedNumber,
+          decisionOutcome: outcome,
+        }),
+        null,
+      ])
+    }
+
+    await clearPatient(client, bedId)
+    await setTriageState(client, bedId, 'cleaning')
+    await writeTriageLog(client, bed, 'cleaning', userId, {
+      source: 'triage',
+      decisionOutcome: outcome,
+      transferErBedId: erBedId ?? null,
+      transferErBedNumber: erBedNumber,
+      erStartStageId: erStageId,
+    })
+    await writeAudit(client, bed, 'cleaning', userId, {
+      source: 'triage',
+      decisionOutcome: outcome,
+      transferErBedId: erBedId ?? null,
+      transferErBedNumber: erBedNumber,
+      erStartStageId: erStageId,
+    })
+
+    await client.query('COMMIT')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    logger.error('Failed to complete triage decision', error as Error, { bedId, outcome })
+    throw error
+  } finally {
+    client.release()
+  }
+}

--- a/src/features/triage/decision-mutations.ts
+++ b/src/features/triage/decision-mutations.ts
@@ -8,6 +8,7 @@ import {
   lockErBed,
   resolveErStartingStage,
 } from './decision-helpers'
+import { writeDecisionRecord } from './decision-record-mutations'
 import {
   clearPatient,
   setTriageState,
@@ -44,13 +45,14 @@ export async function completeTriageDecisionInDB(params: {
       throw new Error('Triage patient details are missing; cannot transfer.')
     }
 
+    const transferErBedId = outcome === 'shift_to_er' ? erBedId ?? null : null
     let erBedNumber: string | null = null
     let erStageId: string | null = null
 
     if (outcome === 'shift_to_er') {
-      if (!erBedId) throw new Error('ER bed selection is required.')
+      if (!transferErBedId) throw new Error('ER bed selection is required.')
 
-      const erBed = await lockErBed(client, erBedId)
+      const erBed = await lockErBed(client, transferErBedId)
       const stageName = (erBed.currentStageName || '').trim().toLowerCase()
       if (erBed.isOccupied || stageName !== 'empty') {
         throw new Error('Selected ER bed is not available.')
@@ -96,7 +98,7 @@ export async function completeTriageDecisionInDB(params: {
           patient.triageCategory,
           erStartStage.id,
           JSON.stringify(triageInfo),
-          erBedId,
+          transferErBedId,
         ]
       )
 
@@ -105,7 +107,7 @@ export async function completeTriageDecisionInDB(params: {
         : null
 
       await client.query(INSERT_BED_STAGE_LOG_SQL, [
-        erBedId,
+        transferErBedId,
         erBed.currentStageId,
         erStartStage.id,
         userId,
@@ -118,7 +120,7 @@ export async function completeTriageDecisionInDB(params: {
       await client.query(INSERT_AUDIT_LOG_SQL, [
         'UPDATE',
         'bed',
-        erBedId,
+        transferErBedId,
         userId,
         JSON.stringify({
           fromStageId: erBed.currentStageId,
@@ -136,19 +138,33 @@ export async function completeTriageDecisionInDB(params: {
       ])
     }
 
+    await writeDecisionRecord(client, {
+      triageBedId: bedId,
+      outcome,
+      erBedId: transferErBedId,
+      erStartStageId: erStageId,
+      userId,
+      patient,
+      metadata: {
+        source: 'triage',
+        triageBedNumber: bed.bedNumber,
+        transferErBedNumber: erBedNumber,
+      },
+    })
+
     await clearPatient(client, bedId)
     await setTriageState(client, bedId, 'cleaning')
     await writeTriageLog(client, bed, 'cleaning', userId, {
       source: 'triage',
       decisionOutcome: outcome,
-      transferErBedId: erBedId ?? null,
+      transferErBedId,
       transferErBedNumber: erBedNumber,
       erStartStageId: erStageId,
     })
     await writeAudit(client, bed, 'cleaning', userId, {
       source: 'triage',
       decisionOutcome: outcome,
-      transferErBedId: erBedId ?? null,
+      transferErBedId,
       transferErBedNumber: erBedNumber,
       erStartStageId: erStageId,
     })

--- a/src/features/triage/decision-record-mutations.ts
+++ b/src/features/triage/decision-record-mutations.ts
@@ -1,0 +1,55 @@
+import type { PoolClient } from 'pg'
+import type { TriageDecisionOutcome } from './types'
+import type { getTriagePatientSnapshot } from './decision-helpers'
+
+type TriagePatientSnapshot = Awaited<ReturnType<typeof getTriagePatientSnapshot>>
+
+export async function writeDecisionRecord(
+  client: PoolClient,
+  params: {
+    triageBedId: string
+    outcome: TriageDecisionOutcome
+    erBedId: string | null
+    erStartStageId: string | null
+    userId: string
+    patient: TriagePatientSnapshot
+    metadata: Record<string, unknown>
+  }
+) {
+  const { triageBedId, outcome, erBedId, erStartStageId, userId, patient, metadata } = params
+
+  await client.query(
+    `INSERT INTO triage_decisions (
+       triage_bed_id,
+       outcome,
+       er_bed_id,
+       er_start_stage_id,
+       patient_uhid,
+       patient_ipd_id,
+       patient_name,
+       patient_age,
+       patient_gender,
+       key_symptom,
+       triage_category,
+       decided_by_user_id,
+       metadata
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb
+     )`,
+    [
+      triageBedId,
+      outcome,
+      erBedId,
+      erStartStageId,
+      patient.patientUhid,
+      patient.patientIpdId,
+      patient.patientName,
+      patient.patientAge,
+      patient.patientGender,
+      patient.keySymptom,
+      patient.triageCategory,
+      userId,
+      JSON.stringify(metadata),
+    ]
+  )
+}

--- a/src/features/triage/mutations.ts
+++ b/src/features/triage/mutations.ts
@@ -1,19 +1,15 @@
 import pool from '@/shared/lib/db'
 import { logger } from '@/shared/config/logger'
 import type { PoolClient } from 'pg'
-import type { TriageDecisionOutcome, TriagePatientDetails, TriageState } from './types'
+import type { TriagePatientDetails, TriageState } from './types'
 import { validateTriageTransition } from './state'
 import { lockTriageBed, type LockedTriageBed } from './triage-bed-lock'
-import {
-  INSERT_AUDIT_LOG_SQL,
-  INSERT_BED_STAGE_LOG_SQL,
-} from '@/features/bed-dashboard/lib/bed-mutations.constants'
 
 function durationFrom(startedAt: Date): number {
   return Date.now() - new Date(startedAt).getTime()
 }
 
-async function writeTriageLog(
+export async function writeTriageLog(
   client: PoolClient,
   bed: LockedTriageBed,
   toState: TriageState,
@@ -30,7 +26,7 @@ async function writeTriageLog(
   )
 }
 
-async function writeAudit(
+export async function writeAudit(
   client: PoolClient,
   bed: LockedTriageBed,
   toState: TriageState,
@@ -54,7 +50,7 @@ async function writeAudit(
   )
 }
 
-async function setTriageState(client: PoolClient, bedId: string, toState: TriageState) {
+export async function setTriageState(client: PoolClient, bedId: string, toState: TriageState) {
   await client.query(
     `UPDATE triage_bed_statuses
      SET state = $1, last_state_change = NOW(), updated_at = NOW()
@@ -87,7 +83,7 @@ async function savePatient(client: PoolClient, bedId: string, patient: TriagePat
   )
 }
 
-async function clearPatient(client: PoolClient, bedId: string) {
+export async function clearPatient(client: PoolClient, bedId: string) {
   await client.query(
     `UPDATE beds
      SET patient_uhid = NULL, patient_ipd_id = NULL, patient_name = NULL,
@@ -100,98 +96,6 @@ async function clearPatient(client: PoolClient, bedId: string) {
   )
 }
 
-type TriagePatientSnapshot = {
-  patientUhid: string | null
-  patientIpdId: string | null
-  patientName: string | null
-  patientAge: number | null
-  patientGender: string | null
-  keySymptom: string | null
-  triageCategory: string | null
-}
-
-async function getTriagePatientSnapshot(client: PoolClient, bedId: string): Promise<TriagePatientSnapshot> {
-  const result = await client.query<TriagePatientSnapshot>(
-    `SELECT
-        patient_uhid as "patientUhid",
-        patient_ipd_id as "patientIpdId",
-        patient_name as "patientName",
-        patient_age as "patientAge",
-        patient_gender as "patientGender",
-        key_symptom as "keySymptom",
-        triage_category as "triageCategory"
-     FROM beds
-     WHERE id = $1`,
-    [bedId]
-  )
-
-  if (!result.rows[0]) {
-    throw new Error('Triage patient details not found.')
-  }
-
-  return result.rows[0]
-}
-
-type LockedErBed = {
-  id: string
-  bedNumber: string
-  currentStageId: string | null
-  currentStageName: string | null
-  lastStageChange: Date | null
-  isOccupied: boolean
-}
-
-async function lockErBed(client: PoolClient, bedId: string): Promise<LockedErBed> {
-  const result = await client.query<LockedErBed>(
-    `
-    SELECT
-      b.id,
-      b.bed_number as "bedNumber",
-      b.current_stage_id as "currentStageId",
-      s.name as "currentStageName",
-      b.last_stage_change as "lastStageChange",
-      b.is_occupied as "isOccupied"
-    FROM beds b
-    JOIN wards w ON w.id = b.ward_id AND w.code = 'ER'
-    LEFT JOIN stages s ON s.id = b.current_stage_id
-    WHERE b.id = $1 AND b.is_active = true
-    FOR UPDATE OF b
-    `,
-    [bedId]
-  )
-
-  const bed = result.rows[0]
-  if (!bed) throw new Error('ER bed not found or inactive.')
-  return bed
-}
-
-async function resolveErStartingStage(client: PoolClient): Promise<{ id: string; name: string }> {
-  const result = await client.query<{ id: string; name: string }>(
-    `
-    SELECT id, name
-    FROM stages
-    WHERE is_active = true AND LOWER(name) = ANY($1)
-    ORDER BY CASE LOWER(name)
-      WHEN 'registration' THEN 1
-      WHEN 'doctor assessment' THEN 2
-      WHEN 'treatment/observation' THEN 3
-      ELSE 99
-    END
-    LIMIT 1
-    `,
-    [[
-      'registration',
-      'doctor assessment',
-      'treatment/observation',
-    ]]
-  )
-
-  if (!result.rows[0]) {
-    throw new Error('ER starting stage not found.')
-  }
-
-  return result.rows[0]
-}
 
 export async function assignPatientInDB(bedId: string, patient: TriagePatientDetails, userId: string) {
   const metadata = { source: 'triage', assignment: true, triageCategory: patient.triageCategory }
@@ -225,150 +129,6 @@ export async function transitionTriageBedInDB(bedId: string, toState: TriageStat
     if (toState === 'cleaning') await clearPatient(client, bedId)
     if (toState === 'empty') await clearPatient(client, bedId)
   })
-}
-
-export async function completeTriageDecisionInDB(params: {
-  bedId: string
-  outcome: TriageDecisionOutcome
-  erBedId?: string | null
-  userId: string
-}) {
-  const client = await pool.connect()
-  const { bedId, outcome, erBedId, userId } = params
-
-  try {
-    await client.query('BEGIN')
-
-    const bed = await lockTriageBed(client, bedId)
-    if (bed.state !== 'decision_made') {
-      throw new Error('Decision outcomes can only be recorded for decision made beds.')
-    }
-
-    const validation = validateTriageTransition(bed.state, 'cleaning')
-    if (validation.success === false) throw new Error(validation.error)
-
-    const patient = await getTriagePatientSnapshot(client, bedId)
-    if (!patient.patientUhid && !patient.patientName) {
-      throw new Error('Triage patient details are missing; cannot transfer.')
-    }
-
-    let erBedNumber: string | null = null
-    let erStageId: string | null = null
-
-    if (outcome === 'shift_to_er') {
-      if (!erBedId) throw new Error('ER bed selection is required.')
-
-      const erBed = await lockErBed(client, erBedId)
-      const stageName = (erBed.currentStageName || '').trim().toLowerCase()
-      if (erBed.isOccupied || stageName !== 'empty') {
-        throw new Error('Selected ER bed is not available.')
-      }
-
-      const erStartStage = await resolveErStartingStage(client)
-      erStageId = erStartStage.id
-      erBedNumber = erBed.bedNumber
-
-      const triageInfo = {
-        patientUhid: patient.patientUhid ?? undefined,
-        patientIpdId: patient.patientIpdId ?? undefined,
-        patientName: patient.patientName ?? undefined,
-        patientAge: patient.patientAge ?? undefined,
-        patientGender: patient.patientGender ?? undefined,
-        keySymptom: patient.keySymptom ?? undefined,
-        triageCategory: patient.triageCategory ?? undefined,
-      }
-
-      await client.query(
-        `UPDATE beds
-         SET patient_uhid = $1,
-             patient_ipd_id = $2,
-             patient_name = $3,
-             patient_age = $4,
-             patient_gender = $5,
-             key_symptom = $6,
-             triage_category = $7,
-             patient_start_time = NOW(),
-             is_occupied = true,
-             current_stage_id = $8,
-             last_stage_change = NOW(),
-             metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{triageInfo}', $9::jsonb, true),
-             updated_at = NOW()
-         WHERE id = $10`,
-        [
-          patient.patientUhid,
-          patient.patientIpdId,
-          patient.patientName,
-          patient.patientAge,
-          patient.patientGender,
-          patient.keySymptom,
-          patient.triageCategory,
-          erStartStage.id,
-          JSON.stringify(triageInfo),
-          erBedId,
-        ]
-      )
-
-      const durationInPreviousStageMs = erBed.lastStageChange
-        ? Date.now() - new Date(erBed.lastStageChange).getTime()
-        : null
-
-      await client.query(INSERT_BED_STAGE_LOG_SQL, [
-        erBedId,
-        erBed.currentStageId,
-        erStartStage.id,
-        userId,
-        durationInPreviousStageMs,
-        'Transferred from triage',
-        null,
-        null,
-      ])
-
-      await client.query(INSERT_AUDIT_LOG_SQL, [
-        'UPDATE',
-        'bed',
-        erBedId,
-        userId,
-        JSON.stringify({
-          fromStageId: erBed.currentStageId,
-          toStageId: erStartStage.id,
-          isOccupied: true,
-        }),
-        'ER bed assigned from triage',
-        JSON.stringify({
-          source: 'triage-transfer',
-          triageBedId: bedId,
-          triageBedNumber: bed.bedNumber,
-          decisionOutcome: outcome,
-        }),
-        null,
-      ])
-    }
-
-    await clearPatient(client, bedId)
-    await setTriageState(client, bedId, 'cleaning')
-    await writeTriageLog(client, bed, 'cleaning', userId, {
-      source: 'triage',
-      decisionOutcome: outcome,
-      transferErBedId: erBedId ?? null,
-      transferErBedNumber: erBedNumber,
-      erStartStageId: erStageId,
-    })
-    await writeAudit(client, bed, 'cleaning', userId, {
-      source: 'triage',
-      decisionOutcome: outcome,
-      transferErBedId: erBedId ?? null,
-      transferErBedNumber: erBedNumber,
-      erStartStageId: erStageId,
-    })
-
-    await client.query('COMMIT')
-  } catch (error) {
-    await client.query('ROLLBACK')
-    logger.error('Failed to complete triage decision', error as Error, { bedId, outcome })
-    throw error
-  } finally {
-    client.release()
-  }
 }
 
 async function runTriageMutation(

--- a/src/features/triage/mutations.ts
+++ b/src/features/triage/mutations.ts
@@ -1,9 +1,13 @@
 import pool from '@/shared/lib/db'
 import { logger } from '@/shared/config/logger'
 import type { PoolClient } from 'pg'
-import type { TriagePatientDetails, TriageState } from './types'
+import type { TriageDecisionOutcome, TriagePatientDetails, TriageState } from './types'
 import { validateTriageTransition } from './state'
 import { lockTriageBed, type LockedTriageBed } from './triage-bed-lock'
+import {
+  INSERT_AUDIT_LOG_SQL,
+  INSERT_BED_STAGE_LOG_SQL,
+} from '@/features/bed-dashboard/lib/bed-mutations.constants'
 
 function durationFrom(startedAt: Date): number {
   return Date.now() - new Date(startedAt).getTime()
@@ -96,6 +100,99 @@ async function clearPatient(client: PoolClient, bedId: string) {
   )
 }
 
+type TriagePatientSnapshot = {
+  patientUhid: string | null
+  patientIpdId: string | null
+  patientName: string | null
+  patientAge: number | null
+  patientGender: string | null
+  keySymptom: string | null
+  triageCategory: string | null
+}
+
+async function getTriagePatientSnapshot(client: PoolClient, bedId: string): Promise<TriagePatientSnapshot> {
+  const result = await client.query<TriagePatientSnapshot>(
+    `SELECT
+        patient_uhid as "patientUhid",
+        patient_ipd_id as "patientIpdId",
+        patient_name as "patientName",
+        patient_age as "patientAge",
+        patient_gender as "patientGender",
+        key_symptom as "keySymptom",
+        triage_category as "triageCategory"
+     FROM beds
+     WHERE id = $1`,
+    [bedId]
+  )
+
+  if (!result.rows[0]) {
+    throw new Error('Triage patient details not found.')
+  }
+
+  return result.rows[0]
+}
+
+type LockedErBed = {
+  id: string
+  bedNumber: string
+  currentStageId: string | null
+  currentStageName: string | null
+  lastStageChange: Date | null
+  isOccupied: boolean
+}
+
+async function lockErBed(client: PoolClient, bedId: string): Promise<LockedErBed> {
+  const result = await client.query<LockedErBed>(
+    `
+    SELECT
+      b.id,
+      b.bed_number as "bedNumber",
+      b.current_stage_id as "currentStageId",
+      s.name as "currentStageName",
+      b.last_stage_change as "lastStageChange",
+      b.is_occupied as "isOccupied"
+    FROM beds b
+    JOIN wards w ON w.id = b.ward_id AND w.code = 'ER'
+    LEFT JOIN stages s ON s.id = b.current_stage_id
+    WHERE b.id = $1 AND b.is_active = true
+    FOR UPDATE OF b
+    `,
+    [bedId]
+  )
+
+  const bed = result.rows[0]
+  if (!bed) throw new Error('ER bed not found or inactive.')
+  return bed
+}
+
+async function resolveErStartingStage(client: PoolClient): Promise<{ id: string; name: string }> {
+  const result = await client.query<{ id: string; name: string }>(
+    `
+    SELECT id, name
+    FROM stages
+    WHERE is_active = true AND LOWER(name) = ANY($1)
+    ORDER BY CASE LOWER(name)
+      WHEN 'registration' THEN 1
+      WHEN 'doctor assessment' THEN 2
+      WHEN 'treatment/observation' THEN 3
+      ELSE 99
+    END
+    LIMIT 1
+    `,
+    [[
+      'registration',
+      'doctor assessment',
+      'treatment/observation',
+    ]]
+  )
+
+  if (!result.rows[0]) {
+    throw new Error('ER starting stage not found.')
+  }
+
+  return result.rows[0]
+}
+
 export async function assignPatientInDB(bedId: string, patient: TriagePatientDetails, userId: string) {
   const metadata = { source: 'triage', assignment: true, triageCategory: patient.triageCategory }
   return runTriageMutation(bedId, 'initial_treatment', userId, metadata, async (client) => {
@@ -128,6 +225,150 @@ export async function transitionTriageBedInDB(bedId: string, toState: TriageStat
     if (toState === 'cleaning') await clearPatient(client, bedId)
     if (toState === 'empty') await clearPatient(client, bedId)
   })
+}
+
+export async function completeTriageDecisionInDB(params: {
+  bedId: string
+  outcome: TriageDecisionOutcome
+  erBedId?: string | null
+  userId: string
+}) {
+  const client = await pool.connect()
+  const { bedId, outcome, erBedId, userId } = params
+
+  try {
+    await client.query('BEGIN')
+
+    const bed = await lockTriageBed(client, bedId)
+    if (bed.state !== 'decision_made') {
+      throw new Error('Decision outcomes can only be recorded for decision made beds.')
+    }
+
+    const validation = validateTriageTransition(bed.state, 'cleaning')
+    if (validation.success === false) throw new Error(validation.error)
+
+    const patient = await getTriagePatientSnapshot(client, bedId)
+    if (!patient.patientUhid && !patient.patientName) {
+      throw new Error('Triage patient details are missing; cannot transfer.')
+    }
+
+    let erBedNumber: string | null = null
+    let erStageId: string | null = null
+
+    if (outcome === 'shift_to_er') {
+      if (!erBedId) throw new Error('ER bed selection is required.')
+
+      const erBed = await lockErBed(client, erBedId)
+      const stageName = (erBed.currentStageName || '').trim().toLowerCase()
+      if (erBed.isOccupied || stageName !== 'empty') {
+        throw new Error('Selected ER bed is not available.')
+      }
+
+      const erStartStage = await resolveErStartingStage(client)
+      erStageId = erStartStage.id
+      erBedNumber = erBed.bedNumber
+
+      const triageInfo = {
+        patientUhid: patient.patientUhid ?? undefined,
+        patientIpdId: patient.patientIpdId ?? undefined,
+        patientName: patient.patientName ?? undefined,
+        patientAge: patient.patientAge ?? undefined,
+        patientGender: patient.patientGender ?? undefined,
+        keySymptom: patient.keySymptom ?? undefined,
+        triageCategory: patient.triageCategory ?? undefined,
+      }
+
+      await client.query(
+        `UPDATE beds
+         SET patient_uhid = $1,
+             patient_ipd_id = $2,
+             patient_name = $3,
+             patient_age = $4,
+             patient_gender = $5,
+             key_symptom = $6,
+             triage_category = $7,
+             patient_start_time = NOW(),
+             is_occupied = true,
+             current_stage_id = $8,
+             last_stage_change = NOW(),
+             metadata = jsonb_set(COALESCE(metadata, '{}'::jsonb), '{triageInfo}', $9::jsonb, true),
+             updated_at = NOW()
+         WHERE id = $10`,
+        [
+          patient.patientUhid,
+          patient.patientIpdId,
+          patient.patientName,
+          patient.patientAge,
+          patient.patientGender,
+          patient.keySymptom,
+          patient.triageCategory,
+          erStartStage.id,
+          JSON.stringify(triageInfo),
+          erBedId,
+        ]
+      )
+
+      const durationInPreviousStageMs = erBed.lastStageChange
+        ? Date.now() - new Date(erBed.lastStageChange).getTime()
+        : null
+
+      await client.query(INSERT_BED_STAGE_LOG_SQL, [
+        erBedId,
+        erBed.currentStageId,
+        erStartStage.id,
+        userId,
+        durationInPreviousStageMs,
+        'Transferred from triage',
+        null,
+        null,
+      ])
+
+      await client.query(INSERT_AUDIT_LOG_SQL, [
+        'UPDATE',
+        'bed',
+        erBedId,
+        userId,
+        JSON.stringify({
+          fromStageId: erBed.currentStageId,
+          toStageId: erStartStage.id,
+          isOccupied: true,
+        }),
+        'ER bed assigned from triage',
+        JSON.stringify({
+          source: 'triage-transfer',
+          triageBedId: bedId,
+          triageBedNumber: bed.bedNumber,
+          decisionOutcome: outcome,
+        }),
+        null,
+      ])
+    }
+
+    await clearPatient(client, bedId)
+    await setTriageState(client, bedId, 'cleaning')
+    await writeTriageLog(client, bed, 'cleaning', userId, {
+      source: 'triage',
+      decisionOutcome: outcome,
+      transferErBedId: erBedId ?? null,
+      transferErBedNumber: erBedNumber,
+      erStartStageId: erStageId,
+    })
+    await writeAudit(client, bed, 'cleaning', userId, {
+      source: 'triage',
+      decisionOutcome: outcome,
+      transferErBedId: erBedId ?? null,
+      transferErBedNumber: erBedNumber,
+      erStartStageId: erStageId,
+    })
+
+    await client.query('COMMIT')
+  } catch (error) {
+    await client.query('ROLLBACK')
+    logger.error('Failed to complete triage decision', error as Error, { bedId, outcome })
+    throw error
+  } finally {
+    client.release()
+  }
 }
 
 async function runTriageMutation(

--- a/src/features/triage/queries.ts
+++ b/src/features/triage/queries.ts
@@ -3,6 +3,7 @@ import { logger } from '@/shared/config/logger'
 import { requireRole } from '@/shared/lib/auth'
 import {
   TRIAGE_BED_NUMBERS,
+  type ErBedOption,
   type TriageBed,
   type TriageCategory,
   type TriageState,
@@ -87,6 +88,40 @@ export async function getTriageDashboardData(): Promise<{
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to load triage beds',
+    }
+  }
+}
+
+export async function getAvailableErBeds(): Promise<{
+  success: boolean
+  data?: { beds: ErBedOption[] }
+  error?: string
+}> {
+  try {
+    await requireRole(['nurse', 'supervisor', 'admin'])
+
+    const result = await query<ErBedOption>(
+      `
+      SELECT
+        b.id,
+        b.bed_number as "bedNumber",
+        COALESCE(s.name, 'Unknown') as "currentStageName"
+      FROM beds b
+      JOIN wards w ON w.id = b.ward_id AND w.code = 'ER'
+      LEFT JOIN stages s ON s.id = b.current_stage_id
+      WHERE b.is_active = true
+        AND b.is_occupied = false
+        AND COALESCE(LOWER(s.name), '') = 'empty'
+      ORDER BY b.bed_number ASC
+      `
+    )
+
+    return { success: true, data: { beds: result.rows } }
+  } catch (error) {
+    logger.error('Failed to fetch available ER beds', error as Error)
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to load ER beds',
     }
   }
 }

--- a/src/features/triage/schemas.ts
+++ b/src/features/triage/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import {
   TRIAGE_CATEGORY_OPTIONS,
+  TRIAGE_DECISION_OUTCOMES,
   TRIAGE_STATES,
   type TriagePatientDetails,
   type TriageState,
@@ -30,9 +31,24 @@ export const transitionTriageBedSchema = z.object({
   toState: z.enum(TRIAGE_STATES),
 })
 
+export const triageDecisionSchema = z.object({
+  bedId: z.string().uuid('Invalid bed ID'),
+  outcome: z.enum(TRIAGE_DECISION_OUTCOMES),
+  erBedId: z.string().uuid('Invalid ER bed ID').optional().nullable(),
+}).superRefine((data, ctx) => {
+  if (data.outcome === 'shift_to_er' && !data.erBedId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['erBedId'],
+      message: 'Select an ER bed for transfer.',
+    })
+  }
+})
+
 export type AssignTriagePatientInput = z.infer<typeof assignTriagePatientSchema>
 export type UpdateTriageDetailsInput = z.infer<typeof updateTriageDetailsSchema>
 export type TransitionTriageBedInput = z.infer<typeof transitionTriageBedSchema>
+export type TriageDecisionInput = z.infer<typeof triageDecisionSchema>
 
 export function normalizePatientDetails(patient: TriagePatientDetails): TriagePatientDetails {
   return {

--- a/src/features/triage/types.ts
+++ b/src/features/triage/types.ts
@@ -16,6 +16,20 @@ export const TRIAGE_STATES = [
 
 export type TriageState = (typeof TRIAGE_STATES)[number]
 
+export const TRIAGE_DECISION_OUTCOMES = [
+  'shift_to_er',
+  'shift_to_icu_ot',
+  'discharge',
+] as const
+
+export type TriageDecisionOutcome = (typeof TRIAGE_DECISION_OUTCOMES)[number]
+
+export const TRIAGE_DECISION_LABELS: Record<TriageDecisionOutcome, string> = {
+  shift_to_er: 'Shift to ER',
+  shift_to_icu_ot: 'Shift to ICU/OT',
+  discharge: 'Discharge',
+}
+
 export const TRIAGE_STATE_LABELS: Record<TriageState, string> = {
   empty: 'Empty',
   initial_treatment: 'Initial Treatment',
@@ -78,6 +92,12 @@ export interface TriageBed {
   lastStateChange: Date
   patientStartTime: Date | null
   patient: Partial<TriagePatientDetails> | null
+}
+
+export interface ErBedOption {
+  id: string
+  bedNumber: string
+  currentStageName: string
 }
 
 export interface TriageDashboardData {


### PR DESCRIPTION
## Description
Implement triage decision outcomes with a server‑validated, transactional transfer to ER beds. The workflow records the outcome, blocks occupied ER beds, assigns the patient to ER (starting the ER workflow), moves the triage bed to cleaning, and writes audit logs. UI now prompts staff for the decision outcome and ER bed selection when needed.

## Linked Issue
Closes #344 

## Type
- [x] Feature
- [ ] Bugfix
- [ ] Documentation
- [ ] Refactor
- [ ] Test

## Checklist

### Code Quality
- [x] No file exceeds 200 lines (except lock files: package-lock.json, yarn.lock, pnpm-lock.yaml)
- [x] Code is properly formatted
- [x] TypeScript types are properly defined
- [x] No ESLint errors or warnings